### PR TITLE
Add md-to-telegraph CLI and defer title cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ This workspace contains two reusable packages used by the bot:
 - [`markdown-this`](packages/markdown-this/README.md): extracts web pages and supported special URLs as Markdown.
 - [`md-to-telegraph`](packages/md-to-telegraph/README.md): converts Markdown into Telegraph DOM nodes.
 
+The `md-to-telegraph` package also provides an `md-to-telegraph` CLI for
+publishing a Markdown file or stdin directly.
+
 Each package has its own version and can be released independently from this workspace.
 
 ### Independent releases

--- a/packages/markdown-this/src/markdown_this/__init__.py
+++ b/packages/markdown-this/src/markdown_this/__init__.py
@@ -19,7 +19,6 @@ from markdown_this.markdown import (
     _strip_badge_paragraphs,
     extract_intro,
     markdown_to_text,
-    strip_leading_title_heading,
 )
 
 __all__ = [
@@ -41,5 +40,4 @@ __all__ = [
     "make_images_absolute",
     "markdown_to_text",
     "preprocess_figures",
-    "strip_leading_title_heading",
 ]

--- a/packages/markdown-this/src/markdown_this/extractor.py
+++ b/packages/markdown-this/src/markdown_this/extractor.py
@@ -21,7 +21,6 @@ from markdown_this.markdown import (
     _normalize_markdown_links,
     extract_intro,
     markdown_to_text,
-    strip_leading_title_heading,
 )
 
 logger = getLogger(__name__)
@@ -41,7 +40,7 @@ def _finalize_content(
     intro_min_length: int,
 ) -> tuple[str, str, str, str]:
     """Normalize extracted Markdown and derive its fallback text and intro."""
-    content_markdown = strip_leading_title_heading(markdown, title).strip()
+    content_markdown = markdown.strip()
     content_fallback = fallback_text if fallback_text is not None else markdown_to_text(content_markdown)
     intro = extract_intro(content_markdown, content_fallback, intro_min_length)
     return title, content_markdown, content_fallback, intro

--- a/packages/markdown-this/src/markdown_this/markdown.py
+++ b/packages/markdown-this/src/markdown_this/markdown.py
@@ -107,15 +107,6 @@ def _normalize_markdown_links(markdown: str) -> str:
     return _HARD_BREAK_BEFORE_LINK_RE.sub("\n", normalized)
 
 
-def strip_leading_title_heading(markdown: str, title: str) -> str:
-    """Remove a leading Markdown heading when it duplicates *title*."""
-    stripped = markdown.lstrip("\n")
-    match = re.match(r"^#{1,6}\s+(.*)\s*$", stripped, re.MULTILINE)
-    if match and match.group(1).strip().lower() == title.strip().lower():
-        return stripped[match.end() :].lstrip("\n")
-    return markdown
-
-
 def markdown_to_text(markdown_text: str) -> str:
     """Reduce Markdown to plain text suitable for previews."""
     text = markdown_text

--- a/packages/markdown-this/tests/test_github.py
+++ b/packages/markdown-this/tests/test_github.py
@@ -27,7 +27,6 @@ from markdown_this import (
     make_images_absolute,
     markdown_to_text,
     preprocess_figures,
-    strip_leading_title_heading,
 )
 from markdown_this import extractor as extractor_module
 from markdown_this import html as html_module

--- a/packages/markdown-this/tests/test_html.py
+++ b/packages/markdown-this/tests/test_html.py
@@ -27,7 +27,6 @@ from markdown_this import (
     make_images_absolute,
     markdown_to_text,
     preprocess_figures,
-    strip_leading_title_heading,
 )
 from markdown_this import extractor as extractor_module
 from markdown_this import html as html_module

--- a/packages/markdown-this/tests/test_markdown.py
+++ b/packages/markdown-this/tests/test_markdown.py
@@ -27,7 +27,6 @@ from markdown_this import (
     make_images_absolute,
     markdown_to_text,
     preprocess_figures,
-    strip_leading_title_heading,
 )
 from markdown_this import extractor as extractor_module
 from markdown_this import html as html_module
@@ -283,64 +282,6 @@ def test_normalize_markdown_links_converts_hard_break_before_inline_link() -> No
         "[coffee](https://example.com/coffee), or\n"
         "[suggest what comes next](https://example.com/next)"
     )
-
-
-# ---------------------------------------------------------------------------
-# strip_leading_title_heading tests
-# ---------------------------------------------------------------------------
-
-
-def test_strip_leading_title_heading_exact_match() -> None:
-    """The leading h1 heading is removed when it exactly matches the title."""
-    md = "# My Article Title\n\nSome content here."
-    result = strip_leading_title_heading(md, "My Article Title")
-    assert result == "Some content here."
-    assert "My Article Title" not in result
-
-
-def test_strip_leading_title_heading_case_insensitive() -> None:
-    """The comparison is case-insensitive."""
-    md = "# the machines are fine. I'm worried about us.\n\nContent."
-    result = strip_leading_title_heading(md, "The machines are fine. I'm worried about us.")
-    assert "the machines are fine" not in result
-    assert "Content." in result
-
-
-def test_strip_leading_title_heading_no_match_kept() -> None:
-    """The heading is kept when its text does not match the title."""
-    md = "# Different Title\n\nContent."
-    result = strip_leading_title_heading(md, "My Article")
-    assert result == md
-
-
-def test_strip_leading_title_heading_h2_removed() -> None:
-    """Works for h2 headings as well."""
-    md = "## Section Heading\n\nContent."
-    result = strip_leading_title_heading(md, "Section Heading")
-    assert "Section Heading" not in result
-    assert "Content." in result
-
-
-def test_strip_leading_title_heading_no_heading_unchanged() -> None:
-    """Markdown without a leading heading is returned unchanged."""
-    md = "Just a paragraph with no heading."
-    result = strip_leading_title_heading(md, "Just a paragraph with no heading.")
-    assert result == md
-
-
-def test_strip_leading_title_heading_leading_blank_lines_ignored() -> None:
-    """Leading blank lines before the heading are ignored."""
-    md = "\n\n# My Title\n\nContent."
-    result = strip_leading_title_heading(md, "My Title")
-    assert "My Title" not in result
-    assert "Content." in result
-
-
-def test_strip_leading_title_heading_trailing_blank_lines_stripped() -> None:
-    """Blank lines between the removed heading and content are stripped."""
-    md = "# My Title\n\n\nContent paragraph."
-    result = strip_leading_title_heading(md, "My Title")
-    assert result == "Content paragraph."
 
 
 # ---------------------------------------------------------------------------

--- a/packages/markdown-this/tests/test_special_urls.py
+++ b/packages/markdown-this/tests/test_special_urls.py
@@ -27,7 +27,6 @@ from markdown_this import (
     make_images_absolute,
     markdown_to_text,
     preprocess_figures,
-    strip_leading_title_heading,
 )
 from markdown_this import extractor as extractor_module
 from markdown_this import html as html_module
@@ -328,8 +327,8 @@ def test_extract_main_content_handles_special_and_generic_paths() -> None:
         ),
     ):
         result = extractor_module.extract_main_content("https://github.com/owner/repo")
-        assert result[1] == "Repo content"
-        assert result[2] == "Repo content"
+        assert result[1] == "# Repo\n\nRepo content"
+        assert result[2] == "Repo\n\nRepo content"
 
     with (
         unittest.mock.patch("markdown_this.extractor.fetch_github_blob_markdown", return_value=None),

--- a/packages/md-to-telegraph/README.md
+++ b/packages/md-to-telegraph/README.md
@@ -62,6 +62,19 @@ url = create_page(
 )
 ```
 
+The same operation is available as a command-line tool. A file uses its stem
+as the default title; stdin requires `--title`:
+
+```bash
+md-to-telegraph article.md --access-token "$TELEGRAPH_API_TOKEN"
+cat article.md | md-to-telegraph --title "An article"
+```
+
+The token can be passed with `--access-token` or read from
+`TELEGRAPH_API_TOKEN`. To create a new Telegraph account explicitly and use
+its token for the page, add `--create-account` (optionally with `--short-name`).
+The account creation uses Telegraph's `createAccount` method.
+
 ## Markdown features supported
 
 | Markdown element       | Telegraph output           |

--- a/packages/md-to-telegraph/README.md
+++ b/packages/md-to-telegraph/README.md
@@ -63,7 +63,8 @@ url = create_page(
 ```
 
 The same operation is available as a command-line tool. A file uses its stem
-as the default title; stdin requires `--title`:
+as the default title; stdin uses its first Markdown heading, or accepts an
+explicit `--title`:
 
 ```bash
 md-to-telegraph article.md --access-token "$TELEGRAPH_API_TOKEN"

--- a/packages/md-to-telegraph/pyproject.toml
+++ b/packages/md-to-telegraph/pyproject.toml
@@ -17,6 +17,9 @@ Homepage = "https://github.com/mgaitan/lobstersgram/tree/main/packages/md-to-tel
 Repository = "https://github.com/mgaitan/lobstersgram"
 Issues = "https://github.com/mgaitan/lobstersgram/issues"
 
+[project.scripts]
+md-to-telegraph = "md_to_telegraph.cli:main"
+
 [build-system]
 requires = ["uv_build>=0.7,<0.12"]
 build-backend = "uv_build"

--- a/packages/md-to-telegraph/src/md_to_telegraph/__init__.py
+++ b/packages/md-to-telegraph/src/md_to_telegraph/__init__.py
@@ -1,10 +1,20 @@
+from md_to_telegraph.markdown import strip_leading_title_heading
 from md_to_telegraph.md_to_dom import content_to_telegraph, md_to_telegraph
-from md_to_telegraph.telegraph import TelegraphAPIError, create_page, warm_telegraph_cache
+from md_to_telegraph.telegraph import (
+    TelegraphAPIError,
+    TelegraphTokenError,
+    create_account,
+    create_page,
+    warm_telegraph_cache,
+)
 
 __all__ = [
     "TelegraphAPIError",
+    "TelegraphTokenError",
     "content_to_telegraph",
+    "create_account",
     "create_page",
     "md_to_telegraph",
+    "strip_leading_title_heading",
     "warm_telegraph_cache",
 ]

--- a/packages/md-to-telegraph/src/md_to_telegraph/cli.py
+++ b/packages/md-to-telegraph/src/md_to_telegraph/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -37,6 +38,14 @@ def _read_markdown(path: Path | None) -> str:
     return path.read_text(encoding="utf-8")
 
 
+def _title_from_markdown(markdown: str) -> str:
+    """Return the first ATX heading, or an empty title when none is present."""
+    lines = markdown.splitlines()
+    first_line = lines[0] if lines else ""
+    match = re.match(r"^\s{0,3}#{1,6}\s+(.+?)\s*#*\s*$", first_line)
+    return match.group(1).strip() if match else ""
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = _parser()
     args = parser.parse_args(argv)
@@ -46,9 +55,9 @@ def main(argv: list[str] | None = None) -> int:
     except OSError as exc:
         parser.error(str(exc))
 
-    title = args.title or (args.path.stem if args.path else "")
+    title = args.title or (args.path.stem if args.path else _title_from_markdown(markdown))
     if not title:
-        parser.error("--title is required when reading Markdown from stdin")
+        parser.error("--title is required when stdin does not start with a Markdown heading")
 
     token = args.access_token or os.getenv("TELEGRAPH_API_TOKEN")
     try:

--- a/packages/md-to-telegraph/src/md_to_telegraph/cli.py
+++ b/packages/md-to-telegraph/src/md_to_telegraph/cli.py
@@ -1,0 +1,79 @@
+"""Command-line interface for publishing Markdown to Telegraph."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from md_to_telegraph.telegraph import (
+    TelegraphAPIError,
+    TelegraphTokenError,
+    create_account,
+    create_page,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Publish Markdown content to Telegraph")
+    parser.add_argument("path", nargs="?", type=Path, help="Markdown file; read stdin when omitted")
+    parser.add_argument("--title", help="Page title; required when reading stdin")
+    parser.add_argument("--fallback-text", default="", help="Plain-text fallback when Markdown has no nodes")
+    parser.add_argument("--source-url", default="", help="Source URL shown as the author link")
+    parser.add_argument("--author-name", default="", help="Author name shown below the page title")
+    parser.add_argument("--access-token", help="Telegraph access token (or TELEGRAPH_API_TOKEN)")
+    parser.add_argument("--create-account", action="store_true", help="Create a Telegraph account for this page")
+    parser.add_argument("--short-name", help="Short name for a newly created Telegraph account")
+    parser.add_argument("--request-timeout", type=int, default=20)
+    parser.add_argument("--retry-attempts", type=int, default=None)
+    parser.add_argument("--no-warm-cache", action="store_true")
+    return parser
+
+
+def _read_markdown(path: Path | None) -> str:
+    if path is None:
+        return sys.stdin.read()
+    return path.read_text(encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _parser()
+    args = parser.parse_args(argv)
+
+    try:
+        markdown = _read_markdown(args.path)
+    except OSError as exc:
+        parser.error(str(exc))
+
+    title = args.title or (args.path.stem if args.path else "")
+    if not title:
+        parser.error("--title is required when reading Markdown from stdin")
+
+    token = args.access_token or os.getenv("TELEGRAPH_API_TOKEN")
+    try:
+        if args.create_account:
+            short_name = (args.short_name or title)[:32] or "md-to-telegraph"
+            token = create_account(
+                short_name=short_name,
+                author_name=args.author_name,
+                author_url=args.source_url,
+                request_timeout=args.request_timeout,
+                retry_attempts=args.retry_attempts,
+            )
+        url = create_page(
+            title=title,
+            content_markdown=markdown,
+            fallback_text=args.fallback_text,
+            source_url=args.source_url,
+            author_name=args.author_name,
+            access_token=token,
+            request_timeout=args.request_timeout,
+            retry_attempts=args.retry_attempts,
+            warm_cache=not args.no_warm_cache,
+        )
+    except (TelegraphAPIError, TelegraphTokenError, OSError) as exc:
+        parser.error(str(exc))
+
+    print(url)
+    return 0

--- a/packages/md-to-telegraph/src/md_to_telegraph/markdown.py
+++ b/packages/md-to-telegraph/src/md_to_telegraph/markdown.py
@@ -1,0 +1,14 @@
+"""Markdown cleanup that belongs to Telegraph page creation."""
+
+from __future__ import annotations
+
+import re
+
+
+def strip_leading_title_heading(markdown: str, title: str) -> str:
+    """Remove a leading Markdown heading when it duplicates the page title."""
+    stripped = markdown.lstrip("\n")
+    match = re.match(r"^#{1,6}\s+(.*)\s*$", stripped, re.MULTILINE)
+    if match and match.group(1).strip().lower() == title.strip().lower():
+        return stripped[match.end() :].lstrip("\n")
+    return markdown

--- a/packages/md-to-telegraph/src/md_to_telegraph/telegraph.py
+++ b/packages/md-to-telegraph/src/md_to_telegraph/telegraph.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import time
+from pathlib import Path
 
 import requests
 
+from md_to_telegraph.markdown import strip_leading_title_heading
 from md_to_telegraph.md_to_dom import content_to_telegraph
 
 logger = logging.getLogger(__name__)
@@ -15,6 +18,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_REQUEST_TIMEOUT = 20
 HTTP_SERVER_ERROR_MIN = 500
 TELEGRAPH_CREATE_PAGE_URL = "https://api.telegra.ph/createPage"
+TELEGRAPH_CREATE_ACCOUNT_URL = "https://api.telegra.ph/createAccount"
 
 
 class TelegraphAPIError(RuntimeError):
@@ -25,16 +29,24 @@ class TelegraphAPIError(RuntimeError):
         self.data = data
 
 
+class TelegraphTokenError(RuntimeError):
+    """Raised when a page needs an access token but none was provided."""
+
+    def __init__(self) -> None:
+        super().__init__("Pass access_token or set TELEGRAPH_API_TOKEN before creating a page")
+
+
 def _post_with_retry(
+    endpoint: str,
     payload: dict[str, object],
     request_timeout: int,
     retry_attempts: int | None,
-) -> str:
-    """Create a Telegraph page, retrying transient responses when requested."""
+) -> dict[str, object]:
+    """POST a Telegraph API method, retrying transient responses when requested."""
     attempts = max(1, retry_attempts or 1)
     for attempt in range(1, attempts + 1):
         backoff = min(2.0**attempt, 30.0)
-        response = requests.post(TELEGRAPH_CREATE_PAGE_URL, data=payload, timeout=request_timeout)
+        response = requests.post(endpoint, data=payload, timeout=request_timeout)
         if response.status_code >= HTTP_SERVER_ERROR_MIN:
             logger.warning("Telegraph server error status=%s attempt=%s/%s", response.status_code, attempt, attempts)
             if attempt < attempts:
@@ -48,9 +60,30 @@ def _post_with_retry(
                 time.sleep(backoff)
                 continue
             raise TelegraphAPIError(data)
-        return str(data["result"]["url"])
+        return data
     msg = "Telegraph request exhausted all attempts without raising"  # pragma: no cover
     raise AssertionError(msg)  # pragma: no cover
+
+
+def create_account(
+    short_name: str,
+    author_name: str = "",
+    author_url: str = "",
+    *,
+    request_timeout: int = DEFAULT_REQUEST_TIMEOUT,
+    retry_attempts: int | None = None,
+) -> str:
+    """Create a Telegraph account and return its access token."""
+    payload: dict[str, object] = {"short_name": short_name}
+    if author_name:
+        payload["author_name"] = author_name
+    if author_url:
+        payload["author_url"] = author_url
+    data = _post_with_retry(TELEGRAPH_CREATE_ACCOUNT_URL, payload, request_timeout, retry_attempts)
+    result = data.get("result")
+    if not isinstance(result, dict) or not result.get("access_token"):
+        raise TelegraphAPIError(data)
+    return str(result["access_token"])
 
 
 def warm_telegraph_cache(url: str, request_timeout: int = DEFAULT_REQUEST_TIMEOUT) -> None:
@@ -65,11 +98,13 @@ def warm_telegraph_cache(url: str, request_timeout: int = DEFAULT_REQUEST_TIMEOU
 
 
 def create_page(  # noqa: PLR0913
-    access_token: str,
     title: str,
-    content_markdown: str,
+    content_markdown: Path | str,
     fallback_text: str = "",
     source_url: str = "",
+    author_name: str = "",
+    access_token: str | None = None,
+    *,
     request_timeout: int = DEFAULT_REQUEST_TIMEOUT,
     retry_attempts: int | None = None,
     warm_cache: bool = True,
@@ -79,19 +114,28 @@ def create_page(  # noqa: PLR0913
     ``retry_attempts=None`` performs one request. Set it to a larger value to
     retry transient server responses and unsuccessful Telegraph API responses.
     """
-    nodes = content_to_telegraph(content_markdown, fallback_text)
+    token = access_token or os.getenv("TELEGRAPH_API_TOKEN")
+    if not token:
+        raise TelegraphTokenError
+
+    page_title = title[:256]
+    markdown = content_markdown.read_text(encoding="utf-8") if isinstance(content_markdown, Path) else content_markdown
+    markdown = strip_leading_title_heading(markdown, page_title)
+    nodes = content_to_telegraph(markdown, fallback_text)
     payload: dict[str, object] = {
-        "access_token": access_token,
-        "title": title[:256],
+        "access_token": token,
+        "title": page_title,
         "content": json.dumps(nodes, ensure_ascii=False),
         "return_content": False,
     }
+    if author_name:
+        payload["author_name"] = author_name
     if source_url:
-        payload["author_name"] = "Source"
         payload["author_url"] = source_url
 
     logger.debug("Create Telegraph page title=%r url=%s", title[:80], source_url)
-    telegraph_url = _post_with_retry(payload, request_timeout, retry_attempts)
+    data = _post_with_retry(TELEGRAPH_CREATE_PAGE_URL, payload, request_timeout, retry_attempts)
+    telegraph_url = str(data["result"]["url"])
     if warm_cache:
         warm_telegraph_cache(telegraph_url, request_timeout)
     return telegraph_url

--- a/packages/md-to-telegraph/tests/test_cli.py
+++ b/packages/md-to-telegraph/tests/test_cli.py
@@ -85,14 +85,25 @@ def test_main_can_create_an_account(monkeypatch: pytest.MonkeyPatch, capsys: pyt
     assert create_page.call_args.kwargs["access_token"] == "new-token"
 
 
-def test_main_requires_title_for_stdin(
+def test_main_infers_title_from_stdin_heading(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO("# From Markdown\n\nBody"))
+    with unittest.mock.patch.object(cli, "create_page", return_value="https://telegra.ph/inferred") as create:
+        assert cli.main(["--access-token", "token"]) == 0
+
+    assert capsys.readouterr().out == "https://telegra.ph/inferred\n"
+    assert create.call_args.kwargs["title"] == "From Markdown"
+
+
+def test_main_requires_title_when_stdin_has_no_heading(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     monkeypatch.setattr(cli.sys, "stdin", io.StringIO("Body"))
     with pytest.raises(SystemExit):
         cli.main([])
 
-    assert "--title is required" in capsys.readouterr().err
+    assert "does not start with a Markdown heading" in capsys.readouterr().err
 
 
 def test_main_reports_file_and_api_errors(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:

--- a/packages/md-to-telegraph/tests/test_cli.py
+++ b/packages/md-to-telegraph/tests/test_cli.py
@@ -1,0 +1,110 @@
+"""Tests for the md-to-telegraph command-line interface."""
+
+from __future__ import annotations
+
+import io
+import unittest.mock
+from pathlib import Path
+
+import pytest
+from md_to_telegraph import cli
+
+REQUEST_TIMEOUT = 7
+RETRY_ATTEMPTS = 3
+
+
+def test_main_reads_file_and_prints_page_url(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    markdown_path = tmp_path / "article.md"
+    markdown_path.write_text("# Article\n\nBody", encoding="utf-8")
+    with unittest.mock.patch.object(cli, "create_page", return_value="https://telegra.ph/article") as create:
+        assert cli.main([str(markdown_path), "--access-token", "token", "--no-warm-cache"]) == 0
+
+    assert capsys.readouterr().out == "https://telegra.ph/article\n"
+    create.assert_called_once_with(
+        title="article",
+        content_markdown="# Article\n\nBody",
+        fallback_text="",
+        source_url="",
+        author_name="",
+        access_token="token",
+        request_timeout=20,
+        retry_attempts=None,
+        warm_cache=False,
+    )
+
+
+def test_main_reads_stdin_and_uses_explicit_options(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO("Body"))
+    with unittest.mock.patch.object(cli, "create_page", return_value="https://telegra.ph/stdin") as create:
+        assert cli.main(
+            [
+                "--title",
+                "From stdin",
+                "--fallback-text",
+                "Fallback",
+                "--source-url",
+                "https://example.com",
+                "--author-name",
+                "Author",
+                "--access-token",
+                "token",
+                "--request-timeout",
+                str(REQUEST_TIMEOUT),
+                "--retry-attempts",
+                str(RETRY_ATTEMPTS),
+            ]
+        ) == 0
+
+    assert capsys.readouterr().out == "https://telegra.ph/stdin\n"
+    assert create.call_args.kwargs["content_markdown"] == "Body"
+    assert create.call_args.kwargs["title"] == "From stdin"
+    assert create.call_args.kwargs["request_timeout"] == REQUEST_TIMEOUT
+    assert create.call_args.kwargs["retry_attempts"] == RETRY_ATTEMPTS
+    assert create.call_args.kwargs["warm_cache"] is True
+
+
+def test_main_can_create_an_account(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.setenv("TELEGRAPH_API_TOKEN", "unused-environment-token")
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO("Body"))
+    with (
+        unittest.mock.patch.object(cli, "create_account", return_value="new-token") as create_account,
+        unittest.mock.patch.object(cli, "create_page", return_value="https://telegra.ph/new") as create_page,
+    ):
+        assert cli.main(["--title", "A title", "--create-account", "--short-name", "custom"]) == 0
+
+    assert capsys.readouterr().out == "https://telegra.ph/new\n"
+    create_account.assert_called_once_with(
+        short_name="custom",
+        author_name="",
+        author_url="",
+        request_timeout=20,
+        retry_attempts=None,
+    )
+    assert create_page.call_args.kwargs["access_token"] == "new-token"
+
+
+def test_main_requires_title_for_stdin(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO("Body"))
+    with pytest.raises(SystemExit):
+        cli.main([])
+
+    assert "--title is required" in capsys.readouterr().err
+
+
+def test_main_reports_file_and_api_errors(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit):
+        cli.main([str(tmp_path / "missing.md")])
+    assert "missing.md" in capsys.readouterr().err
+
+    markdown_path = tmp_path / "article.md"
+    markdown_path.write_text("Body", encoding="utf-8")
+    with (
+        unittest.mock.patch.object(cli, "create_page", side_effect=cli.TelegraphTokenError()),
+        pytest.raises(SystemExit),
+    ):
+        cli.main([str(markdown_path)])
+    assert "TELEGRAPH_API_TOKEN" in capsys.readouterr().err

--- a/packages/md-to-telegraph/tests/test_telegraph.py
+++ b/packages/md-to-telegraph/tests/test_telegraph.py
@@ -4,10 +4,17 @@ from __future__ import annotations
 
 import json
 import unittest.mock
+from pathlib import Path
 
 import pytest
 import requests
-from md_to_telegraph import TelegraphAPIError, create_page, warm_telegraph_cache
+from md_to_telegraph import (
+    TelegraphAPIError,
+    TelegraphTokenError,
+    create_account,
+    create_page,
+    warm_telegraph_cache,
+)
 from md_to_telegraph import telegraph as telegraph_module
 
 HTTP_CLIENT_ERROR_MIN = 400
@@ -31,6 +38,10 @@ def _success_response(url: str = "https://telegra.ph/page") -> FakeResponse:
     return FakeResponse(200, {"ok": True, "result": {"url": url}})
 
 
+def _account_response(token: str = "new-token") -> FakeResponse:
+    return FakeResponse(200, {"ok": True, "result": {"access_token": token}})
+
+
 def test_create_page_posts_content_and_warms_cache() -> None:
     post_response = _success_response()
     cache_response = FakeResponse(200, {})
@@ -44,6 +55,7 @@ def test_create_page_posts_content_and_warms_cache() -> None:
             content_markdown="# Article\n\nBody",
             fallback_text="Fallback",
             source_url="https://example.com/article",
+            author_name="Source",
             request_timeout=7,
         )
 
@@ -83,12 +95,69 @@ def test_create_page_without_retry_or_cache() -> None:
     post.assert_called_once()
 
 
+def test_create_page_reads_token_from_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TELEGRAPH_API_TOKEN", "environment-token")
+    with unittest.mock.patch.object(telegraph_module.requests, "post", return_value=_success_response()) as post:
+        create_page("Title", "Body", warm_cache=False)
+
+    assert post.call_args.kwargs["data"]["access_token"] == "environment-token"
+
+
+def test_create_page_requires_a_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("TELEGRAPH_API_TOKEN", raising=False)
+    with pytest.raises(TelegraphTokenError):
+        create_page("Title", "Body", warm_cache=False)
+
+
+def test_create_page_reads_markdown_path_and_removes_duplicate_title_heading(tmp_path: Path) -> None:
+    markdown_path = tmp_path / "article.md"
+    markdown_path.write_text("\n\n# Final title\n\nBody", encoding="utf-8")
+    with unittest.mock.patch.object(telegraph_module.requests, "post", return_value=_success_response()) as post:
+        create_page("Final title", markdown_path, access_token="token", warm_cache=False)
+
+    payload = post.call_args.kwargs["data"]
+    assert json.loads(payload["content"]) == [{"tag": "p", "children": ["Body"]}]
+
+
+def test_create_account_posts_account_details() -> None:
+    with unittest.mock.patch.object(
+        telegraph_module.requests, "post", return_value=_account_response()
+    ) as post:
+        token = create_account(
+            "short-name",
+            author_name="Author",
+            author_url="https://example.com/author",
+            request_timeout=9,
+        )
+
+    assert token == "new-token"
+    post.assert_called_once_with(
+        "https://api.telegra.ph/createAccount",
+        data={
+            "short_name": "short-name",
+            "author_name": "Author",
+            "author_url": "https://example.com/author",
+        },
+        timeout=9,
+    )
+
+
+def test_create_account_rejects_missing_token_in_response() -> None:
+    with (
+        unittest.mock.patch.object(
+            telegraph_module.requests, "post", return_value=FakeResponse(200, {"ok": True, "result": {}})
+        ),
+        pytest.raises(TelegraphAPIError),
+    ):
+        create_account("short-name")
+
+
 def test_create_page_retries_server_error(monkeypatch: pytest.MonkeyPatch) -> None:
     responses = [FakeResponse(500, {}), _success_response()]
     with unittest.mock.patch.object(telegraph_module.requests, "post", side_effect=responses):
         sleep = unittest.mock.Mock()
         monkeypatch.setattr(telegraph_module.time, "sleep", sleep)
-        result = create_page("token", "Title", "Body", retry_attempts=2, warm_cache=False)
+        result = create_page("Title", "Body", access_token="token", retry_attempts=2, warm_cache=False)
 
     assert result == "https://telegra.ph/page"
     sleep.assert_called_once_with(2.0)
@@ -100,7 +169,7 @@ def test_create_page_retries_unsuccessful_api_response() -> None:
         unittest.mock.patch.object(telegraph_module.requests, "post", side_effect=responses),
         unittest.mock.patch.object(telegraph_module.time, "sleep"),
     ):
-        result = create_page("token", "Title", "Body", retry_attempts=2, warm_cache=False)
+        result = create_page("Title", "Body", access_token="token", retry_attempts=2, warm_cache=False)
 
     assert result == "https://telegra.ph/page"
 
@@ -112,7 +181,7 @@ def test_create_page_raises_after_api_retries() -> None:
         unittest.mock.patch.object(telegraph_module.time, "sleep"),
         pytest.raises(TelegraphAPIError) as exc_info,
     ):
-        create_page("token", "Title", "Body", retry_attempts=2, warm_cache=False)
+        create_page("Title", "Body", access_token="token", retry_attempts=2, warm_cache=False)
 
     assert exc_info.value.data == {"ok": False, "error": "permanent"}
 
@@ -122,7 +191,7 @@ def test_create_page_raises_for_final_server_error() -> None:
         unittest.mock.patch.object(telegraph_module.requests, "post", return_value=FakeResponse(500, {})),
         pytest.raises(requests.HTTPError),
     ):
-        create_page("token", "Title", "Body", retry_attempts=2, warm_cache=False)
+        create_page("Title", "Body", access_token="token", retry_attempts=2, warm_cache=False)
 
 
 def test_warm_telegraph_cache_ignores_request_errors() -> None:

--- a/src/lobstersgram/main.py
+++ b/src/lobstersgram/main.py
@@ -69,11 +69,12 @@ def build_item_message(item: Item) -> tuple[str, dict[str, str]]:
     )
     telegraph_title = extracted_title if extracted_title and extracted_title != final_url else item.title
     telegraph_url = create_page(
-        access_token=config.TELEGRAPH_ACCESS_TOKEN,
         title=telegraph_title,
         content_markdown=content_markdown,
         fallback_text=fallback_text,
         source_url=final_url,
+        author_name="Source",
+        access_token=config.TELEGRAPH_ACCESS_TOKEN,
         request_timeout=config.REQUEST_TIMEOUT,
         retry_attempts=config.TELEGRAPH_RETRY_ATTEMPTS,
     )


### PR DESCRIPTION
## Summary
- add the `md-to-telegraph` argparse CLI for Markdown files and stdin
- resolve `TELEGRAPH_API_TOKEN` and support explicit Telegraph account creation
- move duplicate-title heading cleanup to the final Telegraph page creation step
- keep `markdown-this` extraction output unchanged and update package docs/tests

## Review context
This is intentionally stacked on PR #64 (`agent/workspace-packages`) and should be reviewed/merged after it.

## Verification
- `178 passed`
- 100% coverage for `markdown-this` and `md-to-telegraph`
- Ruff clean
- `uv build --package md-to-telegraph` clean

Resolves the title-deduplication concern from review discussion `discussion_r3725391269`.