### PR TITLE
Accept local and raw HTML in markdown-this

### DIFF
--- a/packages/markdown-this/README.md
+++ b/packages/markdown-this/README.md
@@ -22,8 +22,29 @@ title, markdown, fallback_text, intro = extract_main_content(
 )
 ```
 
+The source can also be a local HTML file (`Path` or path string) or raw HTML:
+
+```python
+from pathlib import Path
+from markdown_this import extract_main_content
+
+title, markdown, fallback_text, intro = extract_main_content(Path("article.html"))
+title, markdown, fallback_text, intro = extract_main_content("<html><p>...</p></html>")
+```
+
 `extract_main_content` returns the title, extracted Markdown, plain-text
 fallback, and a short introduction suitable for a notification or preview.
+
+The package also installs a `markdown-this` command:
+
+```bash
+markdown-this https://example.com/article
+markdown-this article.html
+cat article.html | markdown-this -
+```
+
+The command writes the extracted Markdown to stdout. Its input may be a URL,
+an existing HTML path, or HTML read from stdin.
 
 The lower-level fetchers and normalization helpers are available from the
 package modules when an application needs more control over the pipeline.

--- a/packages/markdown-this/pyproject.toml
+++ b/packages/markdown-this/pyproject.toml
@@ -19,6 +19,9 @@ Homepage = "https://github.com/mgaitan/lobstersgram/tree/main/packages/markdown-
 Repository = "https://github.com/mgaitan/lobstersgram"
 Issues = "https://github.com/mgaitan/lobstersgram/issues"
 
+[project.scripts]
+markdown-this = "markdown_this.cli:main"
+
 [build-system]
 requires = ["uv_build>=0.7,<0.12"]
 build-backend = "uv_build"

--- a/packages/markdown-this/src/markdown_this/cli.py
+++ b/packages/markdown-this/src/markdown_this/cli.py
@@ -1,0 +1,47 @@
+"""Command-line interface for extracting readable Markdown."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import requests
+
+from markdown_this.extractor import ContentDownloadError, extract_main_content
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Extract readable Markdown from a URL, file, or HTML")
+    parser.add_argument(
+        "source",
+        nargs="?",
+        help="URL, HTML file, or -; read raw HTML from stdin when omitted",
+    )
+    parser.add_argument("--request-timeout", type=int, default=20)
+    parser.add_argument("--min-content-length", type=int, default=200)
+    parser.add_argument("--intro-min-length", type=int, default=40)
+    return parser
+
+
+def _read_source(source: str | None) -> Path | str:
+    if source in (None, "-"):
+        return sys.stdin.read()
+    return source
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _parser()
+    args = parser.parse_args(argv)
+    try:
+        _title, markdown, _fallback_text, _intro = extract_main_content(
+            _read_source(args.source),
+            request_timeout=args.request_timeout,
+            min_content_length=args.min_content_length,
+            intro_min_length=args.intro_min_length,
+        )
+    except (ContentDownloadError, OSError, requests.RequestException) as exc:
+        parser.error(str(exc))
+
+    print(markdown)
+    return 0

--- a/packages/markdown-this/src/markdown_this/extractor.py
+++ b/packages/markdown-this/src/markdown_this/extractor.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import urllib.parse
 from logging import getLogger
+from pathlib import Path
 
 from bs4 import BeautifulSoup
 from markdownify import markdownify as html_to_md
@@ -27,7 +29,7 @@ logger = getLogger(__name__)
 
 
 class ContentDownloadError(RuntimeError):
-    """Raised when a URL cannot provide HTML content."""
+    """Raised when a content source cannot provide HTML content."""
 
     def __init__(self) -> None:
         super().__init__("Failed to download content")
@@ -46,13 +48,54 @@ def _finalize_content(
     return title, content_markdown, content_fallback, intro
 
 
-def extract_main_content(
-    url: str,
-    request_timeout: int = DEFAULT_REQUEST_TIMEOUT,
-    min_content_length: int = 200,
-    intro_min_length: int = 40,
+def _is_http_url(source: str) -> bool:
+    parsed = urllib.parse.urlparse(source)
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+
+
+def _existing_path(source: str) -> Path | None:
+    if source.lstrip().startswith("<"):
+        return None
+    path = Path(source)
+    return path if path.is_file() else None
+
+
+def _extract_html_content(
+    content_html: str,
+    source_label: str,
+    base_url: str,
+    min_content_length: int,
+    intro_min_length: int,
 ) -> tuple[str, str, str, str]:
-    """Return ``(title, markdown, fallback_text, intro)`` for *url*."""
+    if not content_html:
+        raise ContentDownloadError
+
+    content_html_for_markdown = ""
+    title = source_label
+    try:
+        document = Document(content_html)
+        content_html_for_markdown = document.summary() or ""
+        title = document.title() or source_label
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("readability failed error=%s", exc)
+
+    if not content_html_for_markdown or len(content_html_for_markdown.strip()) < min_content_length:
+        content_html_for_markdown = content_html
+
+    content_html_for_markdown = preprocess_figures(make_images_absolute(content_html_for_markdown, base_url))
+    extracted_markdown = html_to_md(content_html_for_markdown)
+    extracted_markdown = _normalize_markdown_links(extracted_markdown)
+    extracted_markdown = _make_markdown_links_absolute(extracted_markdown, base_url)
+    fallback_text = BeautifulSoup(content_html_for_markdown, "html.parser").get_text(separator="\n").strip()
+    return _finalize_content(title, extracted_markdown, fallback_text, intro_min_length)
+
+
+def _extract_url_content(
+    url: str,
+    request_timeout: int,
+    min_content_length: int,
+    intro_min_length: int,
+) -> tuple[str, str, str, str]:
     if github_blob_result := fetch_github_blob_markdown(url, request_timeout):
         title, markdown = github_blob_result
         return _finalize_content(title, markdown, None, intro_min_length)
@@ -66,24 +109,35 @@ def extract_main_content(
         return _finalize_content(title, markdown, None, intro_min_length)
 
     downloaded = fetch_html(url, request_timeout)
-    if not downloaded:
-        raise ContentDownloadError
+    return _extract_html_content(downloaded or "", url, url, min_content_length, intro_min_length)
 
-    content_html = ""
-    title = url
-    try:
-        document = Document(downloaded)
-        content_html = document.summary() or ""
-        title = document.title() or url
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("readability failed error=%s", exc)
 
-    if not content_html or len(content_html.strip()) < min_content_length:
-        content_html = downloaded
+def extract_main_content(
+    source: Path | str,
+    request_timeout: int = DEFAULT_REQUEST_TIMEOUT,
+    min_content_length: int = 200,
+    intro_min_length: int = 40,
+) -> tuple[str, str, str, str]:
+    """Return ``(title, markdown, fallback_text, intro)`` for a URL, path, or HTML."""
+    if isinstance(source, Path):
+        return _extract_html_content(
+            source.read_text(encoding="utf-8"),
+            source.stem,
+            source.as_uri(),
+            min_content_length,
+            intro_min_length,
+        )
 
-    content_html = preprocess_figures(make_images_absolute(content_html, url))
-    extracted_markdown = html_to_md(content_html)
-    extracted_markdown = _normalize_markdown_links(extracted_markdown)
-    extracted_markdown = _make_markdown_links_absolute(extracted_markdown, url)
-    fallback_text = BeautifulSoup(content_html, "html.parser").get_text(separator="\n").strip()
-    return _finalize_content(title, extracted_markdown, fallback_text, intro_min_length)
+    if _is_http_url(source):
+        return _extract_url_content(source, request_timeout, min_content_length, intro_min_length)
+
+    if path := _existing_path(source):
+        return _extract_html_content(
+            path.read_text(encoding="utf-8"),
+            path.stem,
+            path.as_uri(),
+            min_content_length,
+            intro_min_length,
+        )
+
+    return _extract_html_content(source, "HTML content", "", min_content_length, intro_min_length)

--- a/packages/markdown-this/tests/test_cli.py
+++ b/packages/markdown-this/tests/test_cli.py
@@ -1,0 +1,46 @@
+"""Tests for the markdown-this command-line interface."""
+
+from __future__ import annotations
+
+import io
+import unittest.mock
+
+import pytest
+from markdown_this import cli
+
+
+def test_main_reads_source_and_prints_markdown(capsys: pytest.CaptureFixture[str]) -> None:
+    with unittest.mock.patch.object(
+        cli,
+        "extract_main_content",
+        return_value=("Title", "# Title\n\nBody", "Body", "Body"),
+    ) as extract:
+        assert cli.main(["article.html", "--request-timeout", "7"]) == 0
+
+    assert capsys.readouterr().out == "# Title\n\nBody\n"
+    extract.assert_called_once_with("article.html", request_timeout=7, min_content_length=200, intro_min_length=40)
+
+
+def test_main_reads_html_from_stdin(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO("<html><p>Body</p></html>"))
+    with unittest.mock.patch.object(
+        cli,
+        "extract_main_content",
+        return_value=("Title", "Body", "Body", "Body"),
+    ) as extract:
+        assert cli.main(["-", "--min-content-length", "0", "--intro-min-length", "5"]) == 0
+
+    assert capsys.readouterr().out == "Body\n"
+    extract.assert_called_once_with(
+        "<html><p>Body</p></html>", request_timeout=20, min_content_length=0, intro_min_length=5
+    )
+
+
+def test_main_reports_extraction_errors(capsys: pytest.CaptureFixture[str]) -> None:
+    with (
+        unittest.mock.patch.object(cli, "extract_main_content", side_effect=cli.ContentDownloadError),
+        pytest.raises(SystemExit),
+    ):
+        cli.main(["article.html"])
+
+    assert "Failed to download content" in capsys.readouterr().err

--- a/packages/markdown-this/tests/test_extractor.py
+++ b/packages/markdown-this/tests/test_extractor.py
@@ -1,0 +1,45 @@
+"""Tests for extracting content from multiple source types."""
+
+from __future__ import annotations
+
+import unittest.mock
+from pathlib import Path
+
+from markdown_this import extract_main_content
+from markdown_this import extractor as extractor_module
+
+
+def _document() -> unittest.mock.Mock:
+    return unittest.mock.Mock(
+        summary=unittest.mock.Mock(return_value="<article><p>Readable body.</p></article>"),
+        title=unittest.mock.Mock(return_value="Readable title"),
+    )
+
+
+def test_extract_main_content_accepts_path_object(tmp_path: Path) -> None:
+    html_path = tmp_path / "article.html"
+    html_path.write_text("<html><body>Source</body></html>", encoding="utf-8")
+    with unittest.mock.patch.object(extractor_module, "Document", return_value=_document()):
+        title, markdown, fallback_text, intro = extract_main_content(html_path, min_content_length=0)
+
+    assert title == "Readable title"
+    assert markdown == "Readable body."
+    assert fallback_text == "Readable body."
+    assert intro == "Readable body."
+
+
+def test_extract_main_content_accepts_path_string(tmp_path: Path) -> None:
+    html_path = tmp_path / "article.html"
+    html_path.write_text("<html><body>Source</body></html>", encoding="utf-8")
+    with unittest.mock.patch.object(extractor_module, "Document", return_value=_document()):
+        result = extract_main_content(str(html_path), min_content_length=0)
+
+    assert result[0] == "Readable title"
+
+
+def test_extract_main_content_accepts_raw_html() -> None:
+    with unittest.mock.patch.object(extractor_module, "Document", return_value=_document()):
+        result = extract_main_content("<html><body>Raw HTML</body></html>", min_content_length=0)
+
+    assert result[:2] == ("Readable title", "Readable body.")
+


### PR DESCRIPTION
## Summary
- let `extract_main_content` accept URLs, existing paths, or raw HTML
- add the `markdown-this` argparse CLI, reading Markdown output from a URL, file, or stdin
- document the expanded Python API and CLI usage

## Verification
- `185 passed`
- 100% coverage
- Ruff clean
- `uv build --package markdown-this` clean

This PR is based on the merged workspace branch and is independent of the application package.