### PR TITLE
Add md-to-telegraph create-account subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ This workspace contains two reusable packages used by the bot:
 - [`markdown-this`](packages/markdown-this/README.md): extracts web pages and supported special URLs as Markdown.
 - [`md-to-telegraph`](packages/md-to-telegraph/README.md): converts Markdown into Telegraph DOM nodes.
 
+The `md-to-telegraph` package also provides an `md-to-telegraph` CLI for
+publishing a Markdown file or stdin directly.
+
 Each package has its own version and can be released independently from this workspace.
 
 ### Independent releases

--- a/packages/markdown-this/README.md
+++ b/packages/markdown-this/README.md
@@ -34,6 +34,21 @@ title, markdown, fallback_text, intro = extract_main_content("<html><p>...</p></
 
 `extract_main_content` returns the title, extracted Markdown, plain-text
 fallback, and a short introduction suitable for a notification or preview.
+The Markdown value starts with YAML front matter containing the metadata that
+was found, such as `title`, `author`, `url`, and `date`.
+
+For example:
+
+```markdown
+---
+title: An article
+author: An author
+url: https://example.com/article
+date: 2026-08-06
+---
+
+Article content.
+```
 
 The package also installs a `markdown-this` command:
 

--- a/packages/markdown-this/README.md
+++ b/packages/markdown-this/README.md
@@ -22,8 +22,29 @@ title, markdown, fallback_text, intro = extract_main_content(
 )
 ```
 
+The source can also be a local HTML file (`Path` or path string) or raw HTML:
+
+```python
+from pathlib import Path
+from markdown_this import extract_main_content
+
+title, markdown, fallback_text, intro = extract_main_content(Path("article.html"))
+title, markdown, fallback_text, intro = extract_main_content("<html><p>...</p></html>")
+```
+
 `extract_main_content` returns the title, extracted Markdown, plain-text
 fallback, and a short introduction suitable for a notification or preview.
+
+The package also installs a `markdown-this` command:
+
+```bash
+markdown-this https://example.com/article
+markdown-this article.html
+cat article.html | markdown-this -
+```
+
+The command writes the extracted Markdown to stdout. Its input may be a URL,
+an existing HTML path, or HTML read from stdin.
 
 The lower-level fetchers and normalization helpers are available from the
 package modules when an application needs more control over the pipeline.

--- a/packages/markdown-this/pyproject.toml
+++ b/packages/markdown-this/pyproject.toml
@@ -19,6 +19,9 @@ Homepage = "https://github.com/mgaitan/lobstersgram/tree/main/packages/markdown-
 Repository = "https://github.com/mgaitan/lobstersgram"
 Issues = "https://github.com/mgaitan/lobstersgram/issues"
 
+[project.scripts]
+markdown-this = "markdown_this.cli:main"
+
 [build-system]
 requires = ["uv_build>=0.7,<0.12"]
 build-backend = "uv_build"

--- a/packages/markdown-this/pyproject.toml
+++ b/packages/markdown-this/pyproject.toml
@@ -10,6 +10,7 @@ keywords = ["html", "markdown", "readability", "github", "arxiv"]
 dependencies = [
     "beautifulsoup4>=4.14.3",
     "markdownify>=1.2.2",
+    "pyyaml>=6.0.3",
     "readability-lxml>=0.8.4.1",
     "requests>=2.32.5",
 ]

--- a/packages/markdown-this/pyproject.toml
+++ b/packages/markdown-this/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "markdown-this"
-version = "0.1.0"
+version = "0.1.1"
 description = "Extract web pages and supported special URLs as Markdown"
 readme = "README.md"
 authors = [{ name = "Martín Gaitán", email = "gaitan@gmail.com" }]

--- a/packages/markdown-this/src/markdown_this/__init__.py
+++ b/packages/markdown-this/src/markdown_this/__init__.py
@@ -20,6 +20,7 @@ from markdown_this.markdown import (
     extract_intro,
     markdown_to_text,
 )
+from markdown_this.metadata import add_front_matter, extract_html_metadata, split_front_matter
 
 __all__ = [
     "ContentDownloadError",
@@ -30,6 +31,8 @@ __all__ = [
     "_make_markdown_links_absolute",
     "_normalize_markdown_links",
     "_strip_badge_paragraphs",
+    "add_front_matter",
+    "extract_html_metadata",
     "extract_intro",
     "extract_main_content",
     "fetch_arxiv_abstract",
@@ -40,4 +43,5 @@ __all__ = [
     "make_images_absolute",
     "markdown_to_text",
     "preprocess_figures",
+    "split_front_matter",
 ]

--- a/packages/markdown-this/src/markdown_this/__init__.py
+++ b/packages/markdown-this/src/markdown_this/__init__.py
@@ -19,7 +19,6 @@ from markdown_this.markdown import (
     _strip_badge_paragraphs,
     extract_intro,
     markdown_to_text,
-    strip_leading_title_heading,
 )
 
 __all__ = [
@@ -41,5 +40,4 @@ __all__ = [
     "make_images_absolute",
     "markdown_to_text",
     "preprocess_figures",
-    "strip_leading_title_heading",
 ]

--- a/packages/markdown-this/src/markdown_this/cli.py
+++ b/packages/markdown-this/src/markdown_this/cli.py
@@ -1,0 +1,47 @@
+"""Command-line interface for extracting readable Markdown."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import requests
+
+from markdown_this.extractor import ContentDownloadError, extract_main_content
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Extract readable Markdown from a URL, file, or HTML")
+    parser.add_argument(
+        "source",
+        nargs="?",
+        help="URL, HTML file, or -; read raw HTML from stdin when omitted",
+    )
+    parser.add_argument("--request-timeout", type=int, default=20)
+    parser.add_argument("--min-content-length", type=int, default=200)
+    parser.add_argument("--intro-min-length", type=int, default=40)
+    return parser
+
+
+def _read_source(source: str | None) -> Path | str:
+    if source in (None, "-"):
+        return sys.stdin.read()
+    return source
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _parser()
+    args = parser.parse_args(argv)
+    try:
+        _title, markdown, _fallback_text, _intro = extract_main_content(
+            _read_source(args.source),
+            request_timeout=args.request_timeout,
+            min_content_length=args.min_content_length,
+            intro_min_length=args.intro_min_length,
+        )
+    except (ContentDownloadError, OSError, requests.RequestException) as exc:
+        parser.error(str(exc))
+
+    print(markdown)
+    return 0

--- a/packages/markdown-this/src/markdown_this/extractor.py
+++ b/packages/markdown-this/src/markdown_this/extractor.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import urllib.parse
 from logging import getLogger
+from pathlib import Path
 
 from bs4 import BeautifulSoup
 from markdownify import markdownify as html_to_md
@@ -27,7 +29,7 @@ logger = getLogger(__name__)
 
 
 class ContentDownloadError(RuntimeError):
-    """Raised when a URL cannot provide HTML content."""
+    """Raised when a content source cannot provide HTML content."""
 
     def __init__(self) -> None:
         super().__init__("Failed to download content")
@@ -46,13 +48,54 @@ def _finalize_content(
     return title, content_markdown, content_fallback, intro
 
 
-def extract_main_content(
-    url: str,
-    request_timeout: int = DEFAULT_REQUEST_TIMEOUT,
-    min_content_length: int = 200,
-    intro_min_length: int = 40,
+def _is_http_url(source: str) -> bool:
+    parsed = urllib.parse.urlparse(source)
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+
+
+def _existing_path(source: str) -> Path | None:
+    if source.lstrip().startswith("<"):
+        return None
+    path = Path(source)
+    return path if path.is_file() else None
+
+
+def _extract_html_content(
+    content_html: str,
+    source_label: str,
+    base_url: str,
+    min_content_length: int,
+    intro_min_length: int,
 ) -> tuple[str, str, str, str]:
-    """Return ``(title, markdown, fallback_text, intro)`` for *url*."""
+    if not content_html:
+        raise ContentDownloadError
+
+    content_html_for_markdown = ""
+    title = source_label
+    try:
+        document = Document(content_html)
+        content_html_for_markdown = document.summary() or ""
+        title = document.title() or source_label
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("readability failed error=%s", exc)
+
+    if not content_html_for_markdown or len(content_html_for_markdown.strip()) < min_content_length:
+        content_html_for_markdown = content_html
+
+    content_html_for_markdown = preprocess_figures(make_images_absolute(content_html_for_markdown, base_url))
+    extracted_markdown = html_to_md(content_html_for_markdown)
+    extracted_markdown = _normalize_markdown_links(extracted_markdown)
+    extracted_markdown = _make_markdown_links_absolute(extracted_markdown, base_url)
+    fallback_text = BeautifulSoup(content_html_for_markdown, "html.parser").get_text(separator="\n").strip()
+    return _finalize_content(title, extracted_markdown, fallback_text, intro_min_length)
+
+
+def _extract_url_content(
+    url: str,
+    request_timeout: int,
+    min_content_length: int,
+    intro_min_length: int,
+) -> tuple[str, str, str, str]:
     if github_blob_result := fetch_github_blob_markdown(url, request_timeout):
         title, markdown = github_blob_result
         return _finalize_content(title, markdown, None, intro_min_length)
@@ -66,24 +109,35 @@ def extract_main_content(
         return _finalize_content(title, markdown, None, intro_min_length)
 
     downloaded = fetch_html(url, request_timeout)
-    if not downloaded:
-        raise ContentDownloadError
+    return _extract_html_content(downloaded or "", url, url, min_content_length, intro_min_length)
 
-    content_html = ""
-    title = url
-    try:
-        document = Document(downloaded)
-        content_html = document.summary() or ""
-        title = document.title() or url
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("readability failed error=%s", exc)
 
-    if not content_html or len(content_html.strip()) < min_content_length:
-        content_html = downloaded
+def extract_main_content(
+    source: Path | str,
+    request_timeout: int = DEFAULT_REQUEST_TIMEOUT,
+    min_content_length: int = 200,
+    intro_min_length: int = 40,
+) -> tuple[str, str, str, str]:
+    """Return ``(title, markdown, fallback_text, intro)`` for a URL, path, or HTML."""
+    if isinstance(source, Path):
+        return _extract_html_content(
+            source.read_text(encoding="utf-8"),
+            source.stem,
+            source.as_uri(),
+            min_content_length,
+            intro_min_length,
+        )
 
-    content_html = preprocess_figures(make_images_absolute(content_html, url))
-    extracted_markdown = html_to_md(content_html)
-    extracted_markdown = _normalize_markdown_links(extracted_markdown)
-    extracted_markdown = _make_markdown_links_absolute(extracted_markdown, url)
-    fallback_text = BeautifulSoup(content_html, "html.parser").get_text(separator="\n").strip()
-    return _finalize_content(title, extracted_markdown, fallback_text, intro_min_length)
+    if _is_http_url(source):
+        return _extract_url_content(source, request_timeout, min_content_length, intro_min_length)
+
+    if path := _existing_path(source):
+        return _extract_html_content(
+            path.read_text(encoding="utf-8"),
+            path.stem,
+            path.as_uri(),
+            min_content_length,
+            intro_min_length,
+        )
+
+    return _extract_html_content(source, "HTML content", "", min_content_length, intro_min_length)

--- a/packages/markdown-this/src/markdown_this/extractor.py
+++ b/packages/markdown-this/src/markdown_this/extractor.py
@@ -24,6 +24,7 @@ from markdown_this.markdown import (
     extract_intro,
     markdown_to_text,
 )
+from markdown_this.metadata import add_front_matter, extract_html_metadata, split_front_matter
 
 logger = getLogger(__name__)
 
@@ -40,12 +41,14 @@ def _finalize_content(
     markdown: str,
     fallback_text: str | None,
     intro_min_length: int,
+    metadata: dict[str, str] | None = None,
 ) -> tuple[str, str, str, str]:
     """Normalize extracted Markdown and derive its fallback text and intro."""
-    content_markdown = markdown.strip()
+    front_matter, content_markdown = split_front_matter(markdown.strip())
+    content_metadata = {**front_matter, **(metadata or {}), "title": title}
     content_fallback = fallback_text if fallback_text is not None else markdown_to_text(content_markdown)
     intro = extract_intro(content_markdown, content_fallback, intro_min_length)
-    return title, content_markdown, content_fallback, intro
+    return title, add_front_matter(content_markdown, content_metadata), content_fallback, intro
 
 
 def _is_http_url(source: str) -> bool:
@@ -60,10 +63,11 @@ def _existing_path(source: str) -> Path | None:
     return path if path.is_file() else None
 
 
-def _extract_html_content(
+def _extract_html_content(  # noqa: PLR0913
     content_html: str,
     source_label: str,
     base_url: str,
+    source_url: str,
     min_content_length: int,
     intro_min_length: int,
 ) -> tuple[str, str, str, str]:
@@ -87,7 +91,10 @@ def _extract_html_content(
     extracted_markdown = _normalize_markdown_links(extracted_markdown)
     extracted_markdown = _make_markdown_links_absolute(extracted_markdown, base_url)
     fallback_text = BeautifulSoup(content_html_for_markdown, "html.parser").get_text(separator="\n").strip()
-    return _finalize_content(title, extracted_markdown, fallback_text, intro_min_length)
+    metadata = extract_html_metadata(content_html)
+    if source_url:
+        metadata["url"] = source_url
+    return _finalize_content(title, extracted_markdown, fallback_text, intro_min_length, metadata)
 
 
 def _extract_url_content(
@@ -98,18 +105,18 @@ def _extract_url_content(
 ) -> tuple[str, str, str, str]:
     if github_blob_result := fetch_github_blob_markdown(url, request_timeout):
         title, markdown = github_blob_result
-        return _finalize_content(title, markdown, None, intro_min_length)
+        return _finalize_content(title, markdown, None, intro_min_length, {"url": url})
 
     if github_result := fetch_github_readme(url, request_timeout):
         title, markdown = github_result
-        return _finalize_content(title, markdown, None, intro_min_length)
+        return _finalize_content(title, markdown, None, intro_min_length, {"url": url})
 
     if arxiv_result := fetch_arxiv_abstract(url, request_timeout):
         title, markdown = arxiv_result
-        return _finalize_content(title, markdown, None, intro_min_length)
+        return _finalize_content(title, markdown, None, intro_min_length, {"url": url})
 
     downloaded = fetch_html(url, request_timeout)
-    return _extract_html_content(downloaded or "", url, url, min_content_length, intro_min_length)
+    return _extract_html_content(downloaded or "", url, url, url, min_content_length, intro_min_length)
 
 
 def extract_main_content(
@@ -124,6 +131,7 @@ def extract_main_content(
             source.read_text(encoding="utf-8"),
             source.stem,
             source.as_uri(),
+            "",
             min_content_length,
             intro_min_length,
         )
@@ -136,8 +144,9 @@ def extract_main_content(
             path.read_text(encoding="utf-8"),
             path.stem,
             path.as_uri(),
+            "",
             min_content_length,
             intro_min_length,
         )
 
-    return _extract_html_content(source, "HTML content", "", min_content_length, intro_min_length)
+    return _extract_html_content(source, "HTML content", "", "", min_content_length, intro_min_length)

--- a/packages/markdown-this/src/markdown_this/extractor.py
+++ b/packages/markdown-this/src/markdown_this/extractor.py
@@ -21,7 +21,6 @@ from markdown_this.markdown import (
     _normalize_markdown_links,
     extract_intro,
     markdown_to_text,
-    strip_leading_title_heading,
 )
 
 logger = getLogger(__name__)
@@ -41,7 +40,7 @@ def _finalize_content(
     intro_min_length: int,
 ) -> tuple[str, str, str, str]:
     """Normalize extracted Markdown and derive its fallback text and intro."""
-    content_markdown = strip_leading_title_heading(markdown, title).strip()
+    content_markdown = markdown.strip()
     content_fallback = fallback_text if fallback_text is not None else markdown_to_text(content_markdown)
     intro = extract_intro(content_markdown, content_fallback, intro_min_length)
     return title, content_markdown, content_fallback, intro

--- a/packages/markdown-this/src/markdown_this/markdown.py
+++ b/packages/markdown-this/src/markdown_this/markdown.py
@@ -107,15 +107,6 @@ def _normalize_markdown_links(markdown: str) -> str:
     return _HARD_BREAK_BEFORE_LINK_RE.sub("\n", normalized)
 
 
-def strip_leading_title_heading(markdown: str, title: str) -> str:
-    """Remove a leading Markdown heading when it duplicates *title*."""
-    stripped = markdown.lstrip("\n")
-    match = re.match(r"^#{1,6}\s+(.*)\s*$", stripped, re.MULTILINE)
-    if match and match.group(1).strip().lower() == title.strip().lower():
-        return stripped[match.end() :].lstrip("\n")
-    return markdown
-
-
 def markdown_to_text(markdown_text: str) -> str:
     """Reduce Markdown to plain text suitable for previews."""
     text = markdown_text

--- a/packages/markdown-this/src/markdown_this/metadata.py
+++ b/packages/markdown-this/src/markdown_this/metadata.py
@@ -1,0 +1,76 @@
+"""YAML front matter and HTML metadata helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import yaml
+from bs4 import BeautifulSoup
+
+METADATA_FIELDS = ("title", "author", "url", "date")
+
+
+def split_front_matter(markdown: str) -> tuple[dict[str, str], str]:
+    """Return front matter metadata and the Markdown body."""
+    lines = markdown.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}, markdown
+
+    try:
+        end = lines.index("---", 1)
+    except ValueError:
+        return {}, markdown
+
+    try:
+        loaded = yaml.safe_load("\n".join(lines[1:end])) or {}
+    except yaml.YAMLError:
+        return {}, markdown
+    if not isinstance(loaded, Mapping):
+        return {}, markdown
+    metadata = {
+        field: str(value)
+        for field in METADATA_FIELDS
+        if (value := loaded.get(field)) is not None and not isinstance(value, (dict, list))
+    }
+    body = "\n".join(lines[end + 1 :]).lstrip("\n")
+    return metadata, body
+
+
+def add_front_matter(markdown: str, metadata: Mapping[str, str]) -> str:
+    """Prepend non-empty metadata fields as YAML front matter."""
+    fields = {field: metadata[field] for field in METADATA_FIELDS if metadata.get(field)}
+    if not fields:
+        return markdown
+    header = yaml.safe_dump(fields, allow_unicode=True, sort_keys=False).strip()
+    return f"---\n{header}\n---\n\n{markdown}" if markdown else f"---\n{header}\n---"
+
+
+def extract_html_metadata(content_html: str) -> dict[str, str]:
+    """Extract common author, canonical URL, and publication date metadata."""
+    soup = BeautifulSoup(content_html, "html.parser")
+
+    def first_meta(*queries: dict[str, str]) -> str:
+        for query in queries:
+            tag = soup.find("meta", attrs=query)
+            if tag and tag.get("content"):
+                return str(tag["content"]).strip()
+        return ""
+
+    author = first_meta(
+        {"name": "author"},
+        {"property": "article:author"},
+        {"name": "byline"},
+        {"itemprop": "author"},
+    )
+    date = first_meta(
+        {"property": "article:published_time"},
+        {"name": "date"},
+        {"itemprop": "datePublished"},
+    )
+    canonical = soup.find("link", rel=lambda value: value and "canonical" in value)
+    url = str(canonical.get("href", "")).strip() if canonical else ""
+    url = url or first_meta({"property": "og:url"})
+    if not date:
+        time_tag = soup.find("time", attrs={"datetime": True})
+        date = str(time_tag["datetime"]).strip() if time_tag else ""
+    return {field: value for field, value in (("author", author), ("url", url), ("date", date)) if value}

--- a/packages/markdown-this/tests/test_cli.py
+++ b/packages/markdown-this/tests/test_cli.py
@@ -1,0 +1,46 @@
+"""Tests for the markdown-this command-line interface."""
+
+from __future__ import annotations
+
+import io
+import unittest.mock
+
+import pytest
+from markdown_this import cli
+
+
+def test_main_reads_source_and_prints_markdown(capsys: pytest.CaptureFixture[str]) -> None:
+    with unittest.mock.patch.object(
+        cli,
+        "extract_main_content",
+        return_value=("Title", "# Title\n\nBody", "Body", "Body"),
+    ) as extract:
+        assert cli.main(["article.html", "--request-timeout", "7"]) == 0
+
+    assert capsys.readouterr().out == "# Title\n\nBody\n"
+    extract.assert_called_once_with("article.html", request_timeout=7, min_content_length=200, intro_min_length=40)
+
+
+def test_main_reads_html_from_stdin(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO("<html><p>Body</p></html>"))
+    with unittest.mock.patch.object(
+        cli,
+        "extract_main_content",
+        return_value=("Title", "Body", "Body", "Body"),
+    ) as extract:
+        assert cli.main(["-", "--min-content-length", "0", "--intro-min-length", "5"]) == 0
+
+    assert capsys.readouterr().out == "Body\n"
+    extract.assert_called_once_with(
+        "<html><p>Body</p></html>", request_timeout=20, min_content_length=0, intro_min_length=5
+    )
+
+
+def test_main_reports_extraction_errors(capsys: pytest.CaptureFixture[str]) -> None:
+    with (
+        unittest.mock.patch.object(cli, "extract_main_content", side_effect=cli.ContentDownloadError),
+        pytest.raises(SystemExit),
+    ):
+        cli.main(["article.html"])
+
+    assert "Failed to download content" in capsys.readouterr().err

--- a/packages/markdown-this/tests/test_extractor.py
+++ b/packages/markdown-this/tests/test_extractor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import unittest.mock
 from pathlib import Path
 
-from markdown_this import extract_main_content
+from markdown_this import extract_main_content, split_front_matter
 from markdown_this import extractor as extractor_module
 
 
@@ -23,7 +23,9 @@ def test_extract_main_content_accepts_path_object(tmp_path: Path) -> None:
         title, markdown, fallback_text, intro = extract_main_content(html_path, min_content_length=0)
 
     assert title == "Readable title"
-    assert markdown == "Readable body."
+    metadata, body = split_front_matter(markdown)
+    assert metadata == {"title": "Readable title"}
+    assert body == "Readable body."
     assert fallback_text == "Readable body."
     assert intro == "Readable body."
 
@@ -41,5 +43,26 @@ def test_extract_main_content_accepts_raw_html() -> None:
     with unittest.mock.patch.object(extractor_module, "Document", return_value=_document()):
         result = extract_main_content("<html><body>Raw HTML</body></html>", min_content_length=0)
 
-    assert result[:2] == ("Readable title", "Readable body.")
+    metadata, body = split_front_matter(result[1])
+    assert result[0] == "Readable title"
+    assert metadata == {"title": "Readable title"}
+    assert body == "Readable body."
 
+
+def test_extract_main_content_emits_html_metadata() -> None:
+    html = (
+        '<meta name="author" content="Author">'
+        '<link rel="canonical" href="https://example.com/article">'
+        '<meta property="article:published_time" content="2026-08-06">'
+        "<p>Raw HTML</p>"
+    )
+    with unittest.mock.patch.object(extractor_module, "Document", return_value=_document()):
+        result = extract_main_content(html, min_content_length=0)
+
+    metadata, _body = split_front_matter(result[1])
+    assert metadata == {
+        "title": "Readable title",
+        "author": "Author",
+        "url": "https://example.com/article",
+        "date": "2026-08-06",
+    }

--- a/packages/markdown-this/tests/test_extractor.py
+++ b/packages/markdown-this/tests/test_extractor.py
@@ -1,0 +1,45 @@
+"""Tests for extracting content from multiple source types."""
+
+from __future__ import annotations
+
+import unittest.mock
+from pathlib import Path
+
+from markdown_this import extract_main_content
+from markdown_this import extractor as extractor_module
+
+
+def _document() -> unittest.mock.Mock:
+    return unittest.mock.Mock(
+        summary=unittest.mock.Mock(return_value="<article><p>Readable body.</p></article>"),
+        title=unittest.mock.Mock(return_value="Readable title"),
+    )
+
+
+def test_extract_main_content_accepts_path_object(tmp_path: Path) -> None:
+    html_path = tmp_path / "article.html"
+    html_path.write_text("<html><body>Source</body></html>", encoding="utf-8")
+    with unittest.mock.patch.object(extractor_module, "Document", return_value=_document()):
+        title, markdown, fallback_text, intro = extract_main_content(html_path, min_content_length=0)
+
+    assert title == "Readable title"
+    assert markdown == "Readable body."
+    assert fallback_text == "Readable body."
+    assert intro == "Readable body."
+
+
+def test_extract_main_content_accepts_path_string(tmp_path: Path) -> None:
+    html_path = tmp_path / "article.html"
+    html_path.write_text("<html><body>Source</body></html>", encoding="utf-8")
+    with unittest.mock.patch.object(extractor_module, "Document", return_value=_document()):
+        result = extract_main_content(str(html_path), min_content_length=0)
+
+    assert result[0] == "Readable title"
+
+
+def test_extract_main_content_accepts_raw_html() -> None:
+    with unittest.mock.patch.object(extractor_module, "Document", return_value=_document()):
+        result = extract_main_content("<html><body>Raw HTML</body></html>", min_content_length=0)
+
+    assert result[:2] == ("Readable title", "Readable body.")
+

--- a/packages/markdown-this/tests/test_github.py
+++ b/packages/markdown-this/tests/test_github.py
@@ -27,7 +27,6 @@ from markdown_this import (
     make_images_absolute,
     markdown_to_text,
     preprocess_figures,
-    strip_leading_title_heading,
 )
 from markdown_this import extractor as extractor_module
 from markdown_this import html as html_module

--- a/packages/markdown-this/tests/test_html.py
+++ b/packages/markdown-this/tests/test_html.py
@@ -27,7 +27,6 @@ from markdown_this import (
     make_images_absolute,
     markdown_to_text,
     preprocess_figures,
-    strip_leading_title_heading,
 )
 from markdown_this import extractor as extractor_module
 from markdown_this import html as html_module

--- a/packages/markdown-this/tests/test_markdown.py
+++ b/packages/markdown-this/tests/test_markdown.py
@@ -27,7 +27,6 @@ from markdown_this import (
     make_images_absolute,
     markdown_to_text,
     preprocess_figures,
-    strip_leading_title_heading,
 )
 from markdown_this import extractor as extractor_module
 from markdown_this import html as html_module
@@ -283,64 +282,6 @@ def test_normalize_markdown_links_converts_hard_break_before_inline_link() -> No
         "[coffee](https://example.com/coffee), or\n"
         "[suggest what comes next](https://example.com/next)"
     )
-
-
-# ---------------------------------------------------------------------------
-# strip_leading_title_heading tests
-# ---------------------------------------------------------------------------
-
-
-def test_strip_leading_title_heading_exact_match() -> None:
-    """The leading h1 heading is removed when it exactly matches the title."""
-    md = "# My Article Title\n\nSome content here."
-    result = strip_leading_title_heading(md, "My Article Title")
-    assert result == "Some content here."
-    assert "My Article Title" not in result
-
-
-def test_strip_leading_title_heading_case_insensitive() -> None:
-    """The comparison is case-insensitive."""
-    md = "# the machines are fine. I'm worried about us.\n\nContent."
-    result = strip_leading_title_heading(md, "The machines are fine. I'm worried about us.")
-    assert "the machines are fine" not in result
-    assert "Content." in result
-
-
-def test_strip_leading_title_heading_no_match_kept() -> None:
-    """The heading is kept when its text does not match the title."""
-    md = "# Different Title\n\nContent."
-    result = strip_leading_title_heading(md, "My Article")
-    assert result == md
-
-
-def test_strip_leading_title_heading_h2_removed() -> None:
-    """Works for h2 headings as well."""
-    md = "## Section Heading\n\nContent."
-    result = strip_leading_title_heading(md, "Section Heading")
-    assert "Section Heading" not in result
-    assert "Content." in result
-
-
-def test_strip_leading_title_heading_no_heading_unchanged() -> None:
-    """Markdown without a leading heading is returned unchanged."""
-    md = "Just a paragraph with no heading."
-    result = strip_leading_title_heading(md, "Just a paragraph with no heading.")
-    assert result == md
-
-
-def test_strip_leading_title_heading_leading_blank_lines_ignored() -> None:
-    """Leading blank lines before the heading are ignored."""
-    md = "\n\n# My Title\n\nContent."
-    result = strip_leading_title_heading(md, "My Title")
-    assert "My Title" not in result
-    assert "Content." in result
-
-
-def test_strip_leading_title_heading_trailing_blank_lines_stripped() -> None:
-    """Blank lines between the removed heading and content are stripped."""
-    md = "# My Title\n\n\nContent paragraph."
-    result = strip_leading_title_heading(md, "My Title")
-    assert result == "Content paragraph."
 
 
 # ---------------------------------------------------------------------------

--- a/packages/markdown-this/tests/test_metadata.py
+++ b/packages/markdown-this/tests/test_metadata.py
@@ -1,0 +1,65 @@
+"""Tests for YAML and HTML metadata handling."""
+
+from __future__ import annotations
+
+from markdown_this import add_front_matter, extract_html_metadata, split_front_matter
+
+
+def test_front_matter_round_trip() -> None:
+    markdown = add_front_matter(
+        "Body",
+        {
+            "title": "An article",
+            "author": "Author",
+            "url": "https://example.com/article",
+            "date": "2026-08-06",
+        },
+    )
+
+    metadata, body = split_front_matter(markdown)
+    assert metadata == {
+        "title": "An article",
+        "author": "Author",
+        "url": "https://example.com/article",
+        "date": "2026-08-06",
+    }
+    assert body == "Body"
+
+
+def test_front_matter_ignores_unknown_and_nested_values() -> None:
+    metadata, body = split_front_matter(
+        "---\ntitle: Title\nunknown: ignored\nextra:\n  value: ignored\n---\n\nBody"
+    )
+    assert metadata == {"title": "Title"}
+    assert body == "Body"
+
+
+def test_front_matter_returns_original_markdown_when_invalid() -> None:
+    markdown = "---\ntitle: Title\n"
+    assert split_front_matter(markdown) == ({}, markdown)
+    assert split_front_matter("---\n- one\n---\n\nBody") == ({}, "---\n- one\n---\n\nBody")
+    invalid_yaml = "---\ntitle: [invalid\n---\n\nBody"
+    assert split_front_matter(invalid_yaml) == ({}, invalid_yaml)
+    assert add_front_matter("Body", {}) == "Body"
+
+
+def test_extract_html_metadata_reads_meta_tags_and_canonical_url() -> None:
+    html = """
+    <link rel="canonical" href="https://example.com/canonical">
+    <meta name="author" content="Author">
+    <meta property="article:published_time" content="2026-08-06">
+    """
+    assert extract_html_metadata(html) == {
+        "author": "Author",
+        "url": "https://example.com/canonical",
+        "date": "2026-08-06",
+    }
+
+
+def test_extract_html_metadata_reads_open_graph_and_time_fallback() -> None:
+    html = '<meta property="og:url" content="https://example.com"><time datetime="2026-08-05">Yesterday</time>'
+    assert extract_html_metadata(html) == {"url": "https://example.com", "date": "2026-08-05"}
+
+
+def test_extract_html_metadata_returns_empty_for_missing_values() -> None:
+    assert extract_html_metadata("<html></html>") == {}

--- a/packages/markdown-this/tests/test_special_urls.py
+++ b/packages/markdown-this/tests/test_special_urls.py
@@ -27,7 +27,6 @@ from markdown_this import (
     make_images_absolute,
     markdown_to_text,
     preprocess_figures,
-    strip_leading_title_heading,
 )
 from markdown_this import extractor as extractor_module
 from markdown_this import html as html_module
@@ -328,8 +327,8 @@ def test_extract_main_content_handles_special_and_generic_paths() -> None:
         ),
     ):
         result = extractor_module.extract_main_content("https://github.com/owner/repo")
-        assert result[1] == "Repo content"
-        assert result[2] == "Repo content"
+        assert result[1] == "# Repo\n\nRepo content"
+        assert result[2] == "Repo\n\nRepo content"
 
     with (
         unittest.mock.patch("markdown_this.extractor.fetch_github_blob_markdown", return_value=None),

--- a/packages/markdown-this/tests/test_special_urls.py
+++ b/packages/markdown-this/tests/test_special_urls.py
@@ -318,7 +318,9 @@ def test_extract_main_content_handles_special_and_generic_paths() -> None:
     ):
         result = extractor_module.extract_main_content("https://github.com/owner/repo")
         assert result[0] == "Repo"
-        assert result[1] == "Repo content"
+        metadata, body = extractor_module.split_front_matter(result[1])
+        assert metadata == {"title": "Repo", "url": "https://github.com/owner/repo"}
+        assert body == "Repo content"
 
     with (
         unittest.mock.patch("markdown_this.extractor.fetch_github_blob_markdown", return_value=None),
@@ -327,7 +329,9 @@ def test_extract_main_content_handles_special_and_generic_paths() -> None:
         ),
     ):
         result = extractor_module.extract_main_content("https://github.com/owner/repo")
-        assert result[1] == "# Repo\n\nRepo content"
+        metadata, body = extractor_module.split_front_matter(result[1])
+        assert metadata == {"title": "Repo", "url": "https://github.com/owner/repo"}
+        assert body == "# Repo\n\nRepo content"
         assert result[2] == "Repo\n\nRepo content"
 
     with (

--- a/packages/md-to-telegraph/README.md
+++ b/packages/md-to-telegraph/README.md
@@ -81,6 +81,20 @@ The token can be passed with `--access-token` or read from
 its token for the page, add `--create-account` (optionally with `--short-name`).
 The account creation uses Telegraph's `createAccount` method.
 
+To create only a token, use the `create-account` subcommand. It prints a shell
+assignment and does not publish a page:
+
+```bash
+md-to-telegraph create-account --short-name lobstersgram
+export $(md-to-telegraph create-account --short-name lobstersgram)
+```
+
+The output can also be appended to a shell startup file:
+
+```bash
+echo "export $(md-to-telegraph create-account --short-name lobstersgram)" >> ~/.bashrc
+```
+
 ## Markdown features supported
 
 | Markdown element       | Telegraph output           |

--- a/packages/md-to-telegraph/README.md
+++ b/packages/md-to-telegraph/README.md
@@ -62,6 +62,19 @@ url = create_page(
 )
 ```
 
+The same operation is available as a command-line tool. A file uses its stem
+as the default title; stdin requires `--title`:
+
+```bash
+md-to-telegraph article.md --access-token "$TELEGRAPH_API_TOKEN"
+cat article.md | md-to-telegraph --title "An article"
+```
+
+The token can be passed with `--access-token` or read from
+`TELEGRAPH_API_TOKEN`. To create a new Telegraph account explicitly and use
+its token for the page, add `--create-account` (optionally with `--short-name`).
+The account creation uses Telegraph's `createAccount` method.
+
 ## Markdown features supported
 
 | Markdown element       | Telegraph output           |

--- a/packages/md-to-telegraph/README.md
+++ b/packages/md-to-telegraph/README.md
@@ -63,7 +63,8 @@ url = create_page(
 ```
 
 The same operation is available as a command-line tool. A file uses its stem
-as the default title; stdin requires `--title`:
+as the default title; stdin uses its first Markdown heading, or accepts an
+explicit `--title`:
 
 ```bash
 md-to-telegraph article.md --access-token "$TELEGRAPH_API_TOKEN"

--- a/packages/md-to-telegraph/README.md
+++ b/packages/md-to-telegraph/README.md
@@ -62,6 +62,11 @@ url = create_page(
 )
 ```
 
+`create_page` reads YAML front matter from `content_markdown`. When these
+arguments are omitted, it uses `title`, `author`, and `url` from the header;
+explicit arguments always take precedence. The `date` field is preserved as
+metadata but Telegraph has no native page-date field.
+
 The same operation is available as a command-line tool. A file uses its stem
 as the default title; stdin uses its first Markdown heading, or accepts an
 explicit `--title`:

--- a/packages/md-to-telegraph/pyproject.toml
+++ b/packages/md-to-telegraph/pyproject.toml
@@ -17,6 +17,9 @@ Homepage = "https://github.com/mgaitan/lobstersgram/tree/main/packages/md-to-tel
 Repository = "https://github.com/mgaitan/lobstersgram"
 Issues = "https://github.com/mgaitan/lobstersgram/issues"
 
+[project.scripts]
+md-to-telegraph = "md_to_telegraph.cli:main"
+
 [build-system]
 requires = ["uv_build>=0.7,<0.12"]
 build-backend = "uv_build"

--- a/packages/md-to-telegraph/pyproject.toml
+++ b/packages/md-to-telegraph/pyproject.toml
@@ -9,6 +9,7 @@ requires-python = ">=3.12"
 keywords = ["markdown", "telegraph", "dom"]
 dependencies = [
     "mistletoe>=1.5.1",
+    "pyyaml>=6.0.3",
     "requests>=2.32.5",
 ]
 

--- a/packages/md-to-telegraph/src/md_to_telegraph/__init__.py
+++ b/packages/md-to-telegraph/src/md_to_telegraph/__init__.py
@@ -1,7 +1,9 @@
-from md_to_telegraph.markdown import strip_leading_title_heading
+from md_to_telegraph.markdown import extract_leading_title, strip_leading_title_heading
 from md_to_telegraph.md_to_dom import content_to_telegraph, md_to_telegraph
+from md_to_telegraph.metadata import split_front_matter
 from md_to_telegraph.telegraph import (
     TelegraphAPIError,
+    TelegraphTitleError,
     TelegraphTokenError,
     create_account,
     create_page,
@@ -10,11 +12,14 @@ from md_to_telegraph.telegraph import (
 
 __all__ = [
     "TelegraphAPIError",
+    "TelegraphTitleError",
     "TelegraphTokenError",
     "content_to_telegraph",
     "create_account",
     "create_page",
+    "extract_leading_title",
     "md_to_telegraph",
+    "split_front_matter",
     "strip_leading_title_heading",
     "warm_telegraph_cache",
 ]

--- a/packages/md-to-telegraph/src/md_to_telegraph/__init__.py
+++ b/packages/md-to-telegraph/src/md_to_telegraph/__init__.py
@@ -1,10 +1,20 @@
+from md_to_telegraph.markdown import strip_leading_title_heading
 from md_to_telegraph.md_to_dom import content_to_telegraph, md_to_telegraph
-from md_to_telegraph.telegraph import TelegraphAPIError, create_page, warm_telegraph_cache
+from md_to_telegraph.telegraph import (
+    TelegraphAPIError,
+    TelegraphTokenError,
+    create_account,
+    create_page,
+    warm_telegraph_cache,
+)
 
 __all__ = [
     "TelegraphAPIError",
+    "TelegraphTokenError",
     "content_to_telegraph",
+    "create_account",
     "create_page",
     "md_to_telegraph",
+    "strip_leading_title_heading",
     "warm_telegraph_cache",
 ]

--- a/packages/md-to-telegraph/src/md_to_telegraph/cli.py
+++ b/packages/md-to-telegraph/src/md_to_telegraph/cli.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import argparse
 import os
-import re
 import sys
 from pathlib import Path
 
+from md_to_telegraph.markdown import extract_leading_title
+from md_to_telegraph.metadata import split_front_matter
 from md_to_telegraph.telegraph import (
     TelegraphAPIError,
+    TelegraphTitleError,
     TelegraphTokenError,
     create_account,
     create_page,
@@ -19,7 +21,7 @@ from md_to_telegraph.telegraph import (
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Publish Markdown content to Telegraph")
     parser.add_argument("path", nargs="?", type=Path, help="Markdown file; read stdin when omitted")
-    parser.add_argument("--title", help="Page title; required when reading stdin")
+    parser.add_argument("--title", help="Page title; overrides YAML front matter and Markdown headings")
     parser.add_argument("--fallback-text", default="", help="Plain-text fallback when Markdown has no nodes")
     parser.add_argument("--source-url", default="", help="Source URL shown as the author link")
     parser.add_argument("--author-name", default="", help="Author name shown below the page title")
@@ -38,14 +40,6 @@ def _read_markdown(path: Path | None) -> str:
     return path.read_text(encoding="utf-8")
 
 
-def _title_from_markdown(markdown: str) -> str:
-    """Return the first ATX heading, or an empty title when none is present."""
-    lines = markdown.splitlines()
-    first_line = lines[0] if lines else ""
-    match = re.match(r"^\s{0,3}#{1,6}\s+(.+?)\s*#*\s*$", first_line)
-    return match.group(1).strip() if match else ""
-
-
 def main(argv: list[str] | None = None) -> int:
     parser = _parser()
     args = parser.parse_args(argv)
@@ -55,9 +49,11 @@ def main(argv: list[str] | None = None) -> int:
     except OSError as exc:
         parser.error(str(exc))
 
-    title = args.title or (args.path.stem if args.path else _title_from_markdown(markdown))
+    metadata, markdown_body = split_front_matter(markdown)
+    title = args.title or metadata.get("title")
+    title = title or (args.path.stem if args.path else extract_leading_title(markdown_body))
     if not title:
-        parser.error("--title is required when stdin does not start with a Markdown heading")
+        parser.error("--title is required when no YAML title or first Markdown heading is available")
 
     token = args.access_token or os.getenv("TELEGRAPH_API_TOKEN")
     try:
@@ -81,7 +77,7 @@ def main(argv: list[str] | None = None) -> int:
             retry_attempts=args.retry_attempts,
             warm_cache=not args.no_warm_cache,
         )
-    except (TelegraphAPIError, TelegraphTokenError, OSError) as exc:
+    except (TelegraphAPIError, TelegraphTitleError, TelegraphTokenError, OSError) as exc:
         parser.error(str(exc))
 
     print(url)

--- a/packages/md-to-telegraph/src/md_to_telegraph/cli.py
+++ b/packages/md-to-telegraph/src/md_to_telegraph/cli.py
@@ -19,7 +19,10 @@ from md_to_telegraph.telegraph import (
 
 
 def _parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Publish Markdown content to Telegraph")
+    parser = argparse.ArgumentParser(
+        description="Publish Markdown content to Telegraph",
+        epilog="Use 'create-account' to print a TELEGRAPH_API_TOKEN assignment.",
+    )
     parser.add_argument("path", nargs="?", type=Path, help="Markdown file; read stdin when omitted")
     parser.add_argument("--title", help="Page title; overrides YAML front matter and Markdown headings")
     parser.add_argument("--fallback-text", default="", help="Plain-text fallback when Markdown has no nodes")
@@ -34,6 +37,34 @@ def _parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _account_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Create a Telegraph account and print its access token")
+    parser.add_argument("--short-name", default="md-to-telegraph", help="Telegraph account short name")
+    parser.add_argument("--author-name", default="", help="Account author name")
+    parser.add_argument("--author-url", default="", help="Account author URL")
+    parser.add_argument("--request-timeout", type=int, default=20)
+    parser.add_argument("--retry-attempts", type=int, default=None)
+    return parser
+
+
+def _create_account(argv: list[str]) -> int:
+    parser = _account_parser()
+    args = parser.parse_args(argv)
+    try:
+        token = create_account(
+            short_name=args.short_name,
+            author_name=args.author_name,
+            author_url=args.author_url,
+            request_timeout=args.request_timeout,
+            retry_attempts=args.retry_attempts,
+        )
+    except (TelegraphAPIError, OSError) as exc:
+        parser.error(str(exc))
+
+    print(f"TELEGRAPH_API_TOKEN={token}")
+    return 0
+
+
 def _read_markdown(path: Path | None) -> str:
     if path is None:
         return sys.stdin.read()
@@ -41,8 +72,12 @@ def _read_markdown(path: Path | None) -> str:
 
 
 def main(argv: list[str] | None = None) -> int:
+    command_line = sys.argv[1:] if argv is None else argv
+    if command_line and command_line[0] == "create-account":
+        return _create_account(command_line[1:])
+
     parser = _parser()
-    args = parser.parse_args(argv)
+    args = parser.parse_args(command_line)
 
     try:
         markdown = _read_markdown(args.path)

--- a/packages/md-to-telegraph/src/md_to_telegraph/cli.py
+++ b/packages/md-to-telegraph/src/md_to_telegraph/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -37,6 +38,14 @@ def _read_markdown(path: Path | None) -> str:
     return path.read_text(encoding="utf-8")
 
 
+def _title_from_markdown(markdown: str) -> str:
+    """Return the first ATX heading, or an empty title when none is present."""
+    lines = markdown.splitlines()
+    first_line = lines[0] if lines else ""
+    match = re.match(r"^\s{0,3}#{1,6}\s+(.+?)\s*#*\s*$", first_line)
+    return match.group(1).strip() if match else ""
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = _parser()
     args = parser.parse_args(argv)
@@ -46,9 +55,9 @@ def main(argv: list[str] | None = None) -> int:
     except OSError as exc:
         parser.error(str(exc))
 
-    title = args.title or (args.path.stem if args.path else "")
+    title = args.title or (args.path.stem if args.path else _title_from_markdown(markdown))
     if not title:
-        parser.error("--title is required when reading Markdown from stdin")
+        parser.error("--title is required when stdin does not start with a Markdown heading")
 
     token = args.access_token or os.getenv("TELEGRAPH_API_TOKEN")
     try:

--- a/packages/md-to-telegraph/src/md_to_telegraph/cli.py
+++ b/packages/md-to-telegraph/src/md_to_telegraph/cli.py
@@ -1,0 +1,79 @@
+"""Command-line interface for publishing Markdown to Telegraph."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from md_to_telegraph.telegraph import (
+    TelegraphAPIError,
+    TelegraphTokenError,
+    create_account,
+    create_page,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Publish Markdown content to Telegraph")
+    parser.add_argument("path", nargs="?", type=Path, help="Markdown file; read stdin when omitted")
+    parser.add_argument("--title", help="Page title; required when reading stdin")
+    parser.add_argument("--fallback-text", default="", help="Plain-text fallback when Markdown has no nodes")
+    parser.add_argument("--source-url", default="", help="Source URL shown as the author link")
+    parser.add_argument("--author-name", default="", help="Author name shown below the page title")
+    parser.add_argument("--access-token", help="Telegraph access token (or TELEGRAPH_API_TOKEN)")
+    parser.add_argument("--create-account", action="store_true", help="Create a Telegraph account for this page")
+    parser.add_argument("--short-name", help="Short name for a newly created Telegraph account")
+    parser.add_argument("--request-timeout", type=int, default=20)
+    parser.add_argument("--retry-attempts", type=int, default=None)
+    parser.add_argument("--no-warm-cache", action="store_true")
+    return parser
+
+
+def _read_markdown(path: Path | None) -> str:
+    if path is None:
+        return sys.stdin.read()
+    return path.read_text(encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _parser()
+    args = parser.parse_args(argv)
+
+    try:
+        markdown = _read_markdown(args.path)
+    except OSError as exc:
+        parser.error(str(exc))
+
+    title = args.title or (args.path.stem if args.path else "")
+    if not title:
+        parser.error("--title is required when reading Markdown from stdin")
+
+    token = args.access_token or os.getenv("TELEGRAPH_API_TOKEN")
+    try:
+        if args.create_account:
+            short_name = (args.short_name or title)[:32] or "md-to-telegraph"
+            token = create_account(
+                short_name=short_name,
+                author_name=args.author_name,
+                author_url=args.source_url,
+                request_timeout=args.request_timeout,
+                retry_attempts=args.retry_attempts,
+            )
+        url = create_page(
+            title=title,
+            content_markdown=markdown,
+            fallback_text=args.fallback_text,
+            source_url=args.source_url,
+            author_name=args.author_name,
+            access_token=token,
+            request_timeout=args.request_timeout,
+            retry_attempts=args.retry_attempts,
+            warm_cache=not args.no_warm_cache,
+        )
+    except (TelegraphAPIError, TelegraphTokenError, OSError) as exc:
+        parser.error(str(exc))
+
+    print(url)
+    return 0

--- a/packages/md-to-telegraph/src/md_to_telegraph/markdown.py
+++ b/packages/md-to-telegraph/src/md_to_telegraph/markdown.py
@@ -5,6 +5,14 @@ from __future__ import annotations
 import re
 
 
+def extract_leading_title(markdown: str) -> str:
+    """Return the first ATX heading title, or an empty string."""
+    lines = markdown.splitlines()
+    first_line = lines[0] if lines else ""
+    match = re.match(r"^\s{0,3}#{1,6}\s+(.+?)\s*#*\s*$", first_line)
+    return match.group(1).strip() if match else ""
+
+
 def strip_leading_title_heading(markdown: str, title: str) -> str:
     """Remove a leading Markdown heading when it duplicates the page title."""
     stripped = markdown.lstrip("\n")

--- a/packages/md-to-telegraph/src/md_to_telegraph/markdown.py
+++ b/packages/md-to-telegraph/src/md_to_telegraph/markdown.py
@@ -1,0 +1,14 @@
+"""Markdown cleanup that belongs to Telegraph page creation."""
+
+from __future__ import annotations
+
+import re
+
+
+def strip_leading_title_heading(markdown: str, title: str) -> str:
+    """Remove a leading Markdown heading when it duplicates the page title."""
+    stripped = markdown.lstrip("\n")
+    match = re.match(r"^#{1,6}\s+(.*)\s*$", stripped, re.MULTILINE)
+    if match and match.group(1).strip().lower() == title.strip().lower():
+        return stripped[match.end() :].lstrip("\n")
+    return markdown

--- a/packages/md-to-telegraph/src/md_to_telegraph/metadata.py
+++ b/packages/md-to-telegraph/src/md_to_telegraph/metadata.py
@@ -1,0 +1,35 @@
+"""YAML front matter helpers for Markdown page inputs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import yaml
+
+METADATA_FIELDS = ("title", "author", "url", "date")
+
+
+def split_front_matter(markdown: str) -> tuple[dict[str, str], str]:
+    """Return front matter metadata and the Markdown body."""
+    lines = markdown.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}, markdown
+
+    try:
+        end = lines.index("---", 1)
+    except ValueError:
+        return {}, markdown
+
+    try:
+        loaded = yaml.safe_load("\n".join(lines[1:end])) or {}
+    except yaml.YAMLError:
+        return {}, markdown
+    if not isinstance(loaded, Mapping):
+        return {}, markdown
+    metadata = {
+        field: str(value)
+        for field in METADATA_FIELDS
+        if (value := loaded.get(field)) is not None and not isinstance(value, (dict, list))
+    }
+    body = "\n".join(lines[end + 1 :]).lstrip("\n")
+    return metadata, body

--- a/packages/md-to-telegraph/src/md_to_telegraph/telegraph.py
+++ b/packages/md-to-telegraph/src/md_to_telegraph/telegraph.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import time
+from pathlib import Path
 
 import requests
 
+from md_to_telegraph.markdown import strip_leading_title_heading
 from md_to_telegraph.md_to_dom import content_to_telegraph
 
 logger = logging.getLogger(__name__)
@@ -15,6 +18,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_REQUEST_TIMEOUT = 20
 HTTP_SERVER_ERROR_MIN = 500
 TELEGRAPH_CREATE_PAGE_URL = "https://api.telegra.ph/createPage"
+TELEGRAPH_CREATE_ACCOUNT_URL = "https://api.telegra.ph/createAccount"
 
 
 class TelegraphAPIError(RuntimeError):
@@ -25,16 +29,24 @@ class TelegraphAPIError(RuntimeError):
         self.data = data
 
 
+class TelegraphTokenError(RuntimeError):
+    """Raised when a page needs an access token but none was provided."""
+
+    def __init__(self) -> None:
+        super().__init__("Pass access_token or set TELEGRAPH_API_TOKEN before creating a page")
+
+
 def _post_with_retry(
+    endpoint: str,
     payload: dict[str, object],
     request_timeout: int,
     retry_attempts: int | None,
-) -> str:
-    """Create a Telegraph page, retrying transient responses when requested."""
+) -> dict[str, object]:
+    """POST a Telegraph API method, retrying transient responses when requested."""
     attempts = max(1, retry_attempts or 1)
     for attempt in range(1, attempts + 1):
         backoff = min(2.0**attempt, 30.0)
-        response = requests.post(TELEGRAPH_CREATE_PAGE_URL, data=payload, timeout=request_timeout)
+        response = requests.post(endpoint, data=payload, timeout=request_timeout)
         if response.status_code >= HTTP_SERVER_ERROR_MIN:
             logger.warning("Telegraph server error status=%s attempt=%s/%s", response.status_code, attempt, attempts)
             if attempt < attempts:
@@ -48,9 +60,30 @@ def _post_with_retry(
                 time.sleep(backoff)
                 continue
             raise TelegraphAPIError(data)
-        return str(data["result"]["url"])
+        return data
     msg = "Telegraph request exhausted all attempts without raising"  # pragma: no cover
     raise AssertionError(msg)  # pragma: no cover
+
+
+def create_account(
+    short_name: str,
+    author_name: str = "",
+    author_url: str = "",
+    *,
+    request_timeout: int = DEFAULT_REQUEST_TIMEOUT,
+    retry_attempts: int | None = None,
+) -> str:
+    """Create a Telegraph account and return its access token."""
+    payload: dict[str, object] = {"short_name": short_name}
+    if author_name:
+        payload["author_name"] = author_name
+    if author_url:
+        payload["author_url"] = author_url
+    data = _post_with_retry(TELEGRAPH_CREATE_ACCOUNT_URL, payload, request_timeout, retry_attempts)
+    result = data.get("result")
+    if not isinstance(result, dict) or not result.get("access_token"):
+        raise TelegraphAPIError(data)
+    return str(result["access_token"])
 
 
 def warm_telegraph_cache(url: str, request_timeout: int = DEFAULT_REQUEST_TIMEOUT) -> None:
@@ -65,11 +98,13 @@ def warm_telegraph_cache(url: str, request_timeout: int = DEFAULT_REQUEST_TIMEOU
 
 
 def create_page(  # noqa: PLR0913
-    access_token: str,
     title: str,
-    content_markdown: str,
+    content_markdown: Path | str,
     fallback_text: str = "",
     source_url: str = "",
+    author_name: str = "",
+    access_token: str | None = None,
+    *,
     request_timeout: int = DEFAULT_REQUEST_TIMEOUT,
     retry_attempts: int | None = None,
     warm_cache: bool = True,
@@ -79,19 +114,28 @@ def create_page(  # noqa: PLR0913
     ``retry_attempts=None`` performs one request. Set it to a larger value to
     retry transient server responses and unsuccessful Telegraph API responses.
     """
-    nodes = content_to_telegraph(content_markdown, fallback_text)
+    token = access_token or os.getenv("TELEGRAPH_API_TOKEN")
+    if not token:
+        raise TelegraphTokenError
+
+    page_title = title[:256]
+    markdown = content_markdown.read_text(encoding="utf-8") if isinstance(content_markdown, Path) else content_markdown
+    markdown = strip_leading_title_heading(markdown, page_title)
+    nodes = content_to_telegraph(markdown, fallback_text)
     payload: dict[str, object] = {
-        "access_token": access_token,
-        "title": title[:256],
+        "access_token": token,
+        "title": page_title,
         "content": json.dumps(nodes, ensure_ascii=False),
         "return_content": False,
     }
+    if author_name:
+        payload["author_name"] = author_name
     if source_url:
-        payload["author_name"] = "Source"
         payload["author_url"] = source_url
 
     logger.debug("Create Telegraph page title=%r url=%s", title[:80], source_url)
-    telegraph_url = _post_with_retry(payload, request_timeout, retry_attempts)
+    data = _post_with_retry(TELEGRAPH_CREATE_PAGE_URL, payload, request_timeout, retry_attempts)
+    telegraph_url = str(data["result"]["url"])
     if warm_cache:
         warm_telegraph_cache(telegraph_url, request_timeout)
     return telegraph_url

--- a/packages/md-to-telegraph/src/md_to_telegraph/telegraph.py
+++ b/packages/md-to-telegraph/src/md_to_telegraph/telegraph.py
@@ -10,8 +10,9 @@ from pathlib import Path
 
 import requests
 
-from md_to_telegraph.markdown import strip_leading_title_heading
+from md_to_telegraph.markdown import extract_leading_title, strip_leading_title_heading
 from md_to_telegraph.md_to_dom import content_to_telegraph
+from md_to_telegraph.metadata import split_front_matter
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +35,13 @@ class TelegraphTokenError(RuntimeError):
 
     def __init__(self) -> None:
         super().__init__("Pass access_token or set TELEGRAPH_API_TOKEN before creating a page")
+
+
+class TelegraphTitleError(RuntimeError):
+    """Raised when a page has no explicit or discoverable title."""
+
+    def __init__(self) -> None:
+        super().__init__("Pass title or include a title in YAML front matter or the first Markdown heading")
 
 
 def _post_with_retry(
@@ -98,8 +106,8 @@ def warm_telegraph_cache(url: str, request_timeout: int = DEFAULT_REQUEST_TIMEOU
 
 
 def create_page(  # noqa: PLR0913
-    title: str,
-    content_markdown: Path | str,
+    title: str | None = None,
+    content_markdown: Path | str = "",
     fallback_text: str = "",
     source_url: str = "",
     author_name: str = "",
@@ -118,9 +126,18 @@ def create_page(  # noqa: PLR0913
     if not token:
         raise TelegraphTokenError
 
-    page_title = title[:256]
     markdown = content_markdown.read_text(encoding="utf-8") if isinstance(content_markdown, Path) else content_markdown
+    metadata, markdown = split_front_matter(markdown)
+    resolved_title = title or metadata.get("title") or extract_leading_title(markdown)
+    if not resolved_title and isinstance(content_markdown, Path):
+        resolved_title = content_markdown.stem
+    if not resolved_title:
+        raise TelegraphTitleError
+
+    page_title = resolved_title[:256]
     markdown = strip_leading_title_heading(markdown, page_title)
+    source_url = source_url or metadata.get("url", "")
+    author_name = author_name or metadata.get("author", "")
     nodes = content_to_telegraph(markdown, fallback_text)
     payload: dict[str, object] = {
         "access_token": token,
@@ -133,7 +150,7 @@ def create_page(  # noqa: PLR0913
     if source_url:
         payload["author_url"] = source_url
 
-    logger.debug("Create Telegraph page title=%r url=%s", title[:80], source_url)
+    logger.debug("Create Telegraph page title=%r url=%s", page_title[:80], source_url)
     data = _post_with_retry(TELEGRAPH_CREATE_PAGE_URL, payload, request_timeout, retry_attempts)
     telegraph_url = str(data["result"]["url"])
     if warm_cache:

--- a/packages/md-to-telegraph/tests/test_cli.py
+++ b/packages/md-to-telegraph/tests/test_cli.py
@@ -85,14 +85,25 @@ def test_main_can_create_an_account(monkeypatch: pytest.MonkeyPatch, capsys: pyt
     assert create_page.call_args.kwargs["access_token"] == "new-token"
 
 
-def test_main_requires_title_for_stdin(
+def test_main_infers_title_from_stdin_heading(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO("# From Markdown\n\nBody"))
+    with unittest.mock.patch.object(cli, "create_page", return_value="https://telegra.ph/inferred") as create:
+        assert cli.main(["--access-token", "token"]) == 0
+
+    assert capsys.readouterr().out == "https://telegra.ph/inferred\n"
+    assert create.call_args.kwargs["title"] == "From Markdown"
+
+
+def test_main_requires_title_when_stdin_has_no_heading(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     monkeypatch.setattr(cli.sys, "stdin", io.StringIO("Body"))
     with pytest.raises(SystemExit):
         cli.main([])
 
-    assert "--title is required" in capsys.readouterr().err
+    assert "does not start with a Markdown heading" in capsys.readouterr().err
 
 
 def test_main_reports_file_and_api_errors(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:

--- a/packages/md-to-telegraph/tests/test_cli.py
+++ b/packages/md-to-telegraph/tests/test_cli.py
@@ -1,0 +1,110 @@
+"""Tests for the md-to-telegraph command-line interface."""
+
+from __future__ import annotations
+
+import io
+import unittest.mock
+from pathlib import Path
+
+import pytest
+from md_to_telegraph import cli
+
+REQUEST_TIMEOUT = 7
+RETRY_ATTEMPTS = 3
+
+
+def test_main_reads_file_and_prints_page_url(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    markdown_path = tmp_path / "article.md"
+    markdown_path.write_text("# Article\n\nBody", encoding="utf-8")
+    with unittest.mock.patch.object(cli, "create_page", return_value="https://telegra.ph/article") as create:
+        assert cli.main([str(markdown_path), "--access-token", "token", "--no-warm-cache"]) == 0
+
+    assert capsys.readouterr().out == "https://telegra.ph/article\n"
+    create.assert_called_once_with(
+        title="article",
+        content_markdown="# Article\n\nBody",
+        fallback_text="",
+        source_url="",
+        author_name="",
+        access_token="token",
+        request_timeout=20,
+        retry_attempts=None,
+        warm_cache=False,
+    )
+
+
+def test_main_reads_stdin_and_uses_explicit_options(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO("Body"))
+    with unittest.mock.patch.object(cli, "create_page", return_value="https://telegra.ph/stdin") as create:
+        assert cli.main(
+            [
+                "--title",
+                "From stdin",
+                "--fallback-text",
+                "Fallback",
+                "--source-url",
+                "https://example.com",
+                "--author-name",
+                "Author",
+                "--access-token",
+                "token",
+                "--request-timeout",
+                str(REQUEST_TIMEOUT),
+                "--retry-attempts",
+                str(RETRY_ATTEMPTS),
+            ]
+        ) == 0
+
+    assert capsys.readouterr().out == "https://telegra.ph/stdin\n"
+    assert create.call_args.kwargs["content_markdown"] == "Body"
+    assert create.call_args.kwargs["title"] == "From stdin"
+    assert create.call_args.kwargs["request_timeout"] == REQUEST_TIMEOUT
+    assert create.call_args.kwargs["retry_attempts"] == RETRY_ATTEMPTS
+    assert create.call_args.kwargs["warm_cache"] is True
+
+
+def test_main_can_create_an_account(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.setenv("TELEGRAPH_API_TOKEN", "unused-environment-token")
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO("Body"))
+    with (
+        unittest.mock.patch.object(cli, "create_account", return_value="new-token") as create_account,
+        unittest.mock.patch.object(cli, "create_page", return_value="https://telegra.ph/new") as create_page,
+    ):
+        assert cli.main(["--title", "A title", "--create-account", "--short-name", "custom"]) == 0
+
+    assert capsys.readouterr().out == "https://telegra.ph/new\n"
+    create_account.assert_called_once_with(
+        short_name="custom",
+        author_name="",
+        author_url="",
+        request_timeout=20,
+        retry_attempts=None,
+    )
+    assert create_page.call_args.kwargs["access_token"] == "new-token"
+
+
+def test_main_requires_title_for_stdin(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO("Body"))
+    with pytest.raises(SystemExit):
+        cli.main([])
+
+    assert "--title is required" in capsys.readouterr().err
+
+
+def test_main_reports_file_and_api_errors(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit):
+        cli.main([str(tmp_path / "missing.md")])
+    assert "missing.md" in capsys.readouterr().err
+
+    markdown_path = tmp_path / "article.md"
+    markdown_path.write_text("Body", encoding="utf-8")
+    with (
+        unittest.mock.patch.object(cli, "create_page", side_effect=cli.TelegraphTokenError()),
+        pytest.raises(SystemExit),
+    ):
+        cli.main([str(markdown_path)])
+    assert "TELEGRAPH_API_TOKEN" in capsys.readouterr().err

--- a/packages/md-to-telegraph/tests/test_cli.py
+++ b/packages/md-to-telegraph/tests/test_cli.py
@@ -65,6 +65,18 @@ def test_main_reads_stdin_and_uses_explicit_options(
     assert create.call_args.kwargs["warm_cache"] is True
 
 
+def test_main_uses_front_matter_title_from_stdin(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    markdown = "---\ntitle: Header title\n---\n\nBody"
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO(markdown))
+    with unittest.mock.patch.object(cli, "create_page", return_value="https://telegra.ph/header") as create:
+        assert cli.main(["--access-token", "token"]) == 0
+
+    assert capsys.readouterr().out == "https://telegra.ph/header\n"
+    assert create.call_args.kwargs["title"] == "Header title"
+
+
 def test_main_can_create_an_account(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
     monkeypatch.setenv("TELEGRAPH_API_TOKEN", "unused-environment-token")
     monkeypatch.setattr(cli.sys, "stdin", io.StringIO("Body"))
@@ -103,7 +115,7 @@ def test_main_requires_title_when_stdin_has_no_heading(
     with pytest.raises(SystemExit):
         cli.main([])
 
-    assert "does not start with a Markdown heading" in capsys.readouterr().err
+    assert "no YAML title" in capsys.readouterr().err
 
 
 def test_main_reports_file_and_api_errors(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:

--- a/packages/md-to-telegraph/tests/test_cli.py
+++ b/packages/md-to-telegraph/tests/test_cli.py
@@ -97,6 +97,52 @@ def test_main_can_create_an_account(monkeypatch: pytest.MonkeyPatch, capsys: pyt
     assert create_page.call_args.kwargs["access_token"] == "new-token"
 
 
+def test_create_account_subcommand_prints_shell_assignment(capsys: pytest.CaptureFixture[str]) -> None:
+    with unittest.mock.patch.object(cli, "create_account", return_value="new-token") as create_account:
+        assert cli.main(
+            [
+                "create-account",
+                "--short-name",
+                "lobstersgram",
+                "--author-name",
+                "Author",
+                "--author-url",
+                "https://example.com",
+                "--request-timeout",
+                "7",
+                "--retry-attempts",
+                "3",
+            ]
+        ) == 0
+
+    assert capsys.readouterr().out == "TELEGRAPH_API_TOKEN=new-token\n"
+    create_account.assert_called_once_with(
+        short_name="lobstersgram",
+        author_name="Author",
+        author_url="https://example.com",
+        request_timeout=7,
+        retry_attempts=3,
+    )
+
+
+def test_create_account_subcommand_uses_default_short_name(capsys: pytest.CaptureFixture[str]) -> None:
+    with unittest.mock.patch.object(cli, "create_account", return_value="new-token") as create_account:
+        assert cli.main(["create-account"]) == 0
+
+    assert capsys.readouterr().out == "TELEGRAPH_API_TOKEN=new-token\n"
+    assert create_account.call_args.kwargs["short_name"] == "md-to-telegraph"
+
+
+def test_create_account_subcommand_reports_api_errors(capsys: pytest.CaptureFixture[str]) -> None:
+    with (
+        unittest.mock.patch.object(cli, "create_account", side_effect=cli.TelegraphAPIError({"error": "bad"})),
+        pytest.raises(SystemExit),
+    ):
+        cli.main(["create-account"])
+
+    assert "Telegraph API error" in capsys.readouterr().err
+
+
 def test_main_infers_title_from_stdin_heading(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/packages/md-to-telegraph/tests/test_metadata.py
+++ b/packages/md-to-telegraph/tests/test_metadata.py
@@ -1,0 +1,26 @@
+"""Tests for reading YAML front matter."""
+
+from md_to_telegraph import split_front_matter
+
+
+def test_split_front_matter_reads_supported_fields() -> None:
+    metadata, body = split_front_matter(
+        "---\ntitle: Title\nauthor: Author\nurl: https://example.com\ndate: 2026-08-06\n---\n\nBody"
+    )
+    assert metadata == {
+        "title": "Title",
+        "author": "Author",
+        "url": "https://example.com",
+        "date": "2026-08-06",
+    }
+    assert body == "Body"
+
+
+def test_split_front_matter_returns_original_without_valid_header() -> None:
+    markdown = "Body"
+    assert split_front_matter(markdown) == ({}, markdown)
+    assert split_front_matter("---\ntitle: Title") == ({}, "---\ntitle: Title")
+    invalid = "---\n- one\n---\n\nBody"
+    assert split_front_matter(invalid) == ({}, invalid)
+    invalid_yaml = "---\ntitle: [invalid\n---\n\nBody"
+    assert split_front_matter(invalid_yaml) == ({}, invalid_yaml)

--- a/packages/md-to-telegraph/tests/test_telegraph.py
+++ b/packages/md-to-telegraph/tests/test_telegraph.py
@@ -10,6 +10,7 @@ import pytest
 import requests
 from md_to_telegraph import (
     TelegraphAPIError,
+    TelegraphTitleError,
     TelegraphTokenError,
     create_account,
     create_page,
@@ -117,6 +118,53 @@ def test_create_page_reads_markdown_path_and_removes_duplicate_title_heading(tmp
 
     payload = post.call_args.kwargs["data"]
     assert json.loads(payload["content"]) == [{"tag": "p", "children": ["Body"]}]
+
+
+def test_create_page_reads_front_matter_defaults() -> None:
+    markdown = "---\ntitle: Front matter title\nauthor: Author\nurl: https://example.com\ndate: 2026-08-06\n---\n\nBody"
+    with unittest.mock.patch.object(telegraph_module.requests, "post", return_value=_success_response()) as post:
+        create_page(content_markdown=markdown, access_token="token", warm_cache=False)
+
+    payload = post.call_args.kwargs["data"]
+    assert payload["title"] == "Front matter title"
+    assert payload["author_name"] == "Author"
+    assert payload["author_url"] == "https://example.com"
+    assert json.loads(payload["content"]) == [{"tag": "p", "children": ["Body"]}]
+
+
+def test_create_page_explicit_values_override_front_matter() -> None:
+    markdown = "---\ntitle: Header title\nauthor: Header author\nurl: https://header.example\n---\n\nBody"
+    with unittest.mock.patch.object(telegraph_module.requests, "post", return_value=_success_response()) as post:
+        create_page(
+            title="Explicit title",
+            content_markdown=markdown,
+            author_name="Explicit author",
+            source_url="https://explicit.example",
+            access_token="token",
+            warm_cache=False,
+        )
+
+    payload = post.call_args.kwargs["data"]
+    assert payload["title"] == "Explicit title"
+    assert payload["author_name"] == "Explicit author"
+    assert payload["author_url"] == "https://explicit.example"
+
+
+def test_create_page_uses_path_stem_without_title(tmp_path: Path) -> None:
+    markdown_path = tmp_path / "article.md"
+    markdown_path.write_text("Body", encoding="utf-8")
+    with unittest.mock.patch.object(telegraph_module.requests, "post", return_value=_success_response()) as post:
+        create_page(content_markdown=markdown_path, access_token="token", warm_cache=False)
+
+    assert post.call_args.kwargs["data"]["title"] == "article"
+
+
+def test_create_page_requires_a_title_for_raw_markdown() -> None:
+    with (
+        unittest.mock.patch.object(telegraph_module.requests, "post", return_value=_success_response()),
+        pytest.raises(TelegraphTitleError),
+    ):
+        create_page(content_markdown="Body", access_token="token", warm_cache=False)
 
 
 def test_create_account_posts_account_details() -> None:

--- a/packages/md-to-telegraph/tests/test_telegraph.py
+++ b/packages/md-to-telegraph/tests/test_telegraph.py
@@ -4,10 +4,17 @@ from __future__ import annotations
 
 import json
 import unittest.mock
+from pathlib import Path
 
 import pytest
 import requests
-from md_to_telegraph import TelegraphAPIError, create_page, warm_telegraph_cache
+from md_to_telegraph import (
+    TelegraphAPIError,
+    TelegraphTokenError,
+    create_account,
+    create_page,
+    warm_telegraph_cache,
+)
 from md_to_telegraph import telegraph as telegraph_module
 
 HTTP_CLIENT_ERROR_MIN = 400
@@ -31,6 +38,10 @@ def _success_response(url: str = "https://telegra.ph/page") -> FakeResponse:
     return FakeResponse(200, {"ok": True, "result": {"url": url}})
 
 
+def _account_response(token: str = "new-token") -> FakeResponse:
+    return FakeResponse(200, {"ok": True, "result": {"access_token": token}})
+
+
 def test_create_page_posts_content_and_warms_cache() -> None:
     post_response = _success_response()
     cache_response = FakeResponse(200, {})
@@ -44,6 +55,7 @@ def test_create_page_posts_content_and_warms_cache() -> None:
             content_markdown="# Article\n\nBody",
             fallback_text="Fallback",
             source_url="https://example.com/article",
+            author_name="Source",
             request_timeout=7,
         )
 
@@ -83,12 +95,69 @@ def test_create_page_without_retry_or_cache() -> None:
     post.assert_called_once()
 
 
+def test_create_page_reads_token_from_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TELEGRAPH_API_TOKEN", "environment-token")
+    with unittest.mock.patch.object(telegraph_module.requests, "post", return_value=_success_response()) as post:
+        create_page("Title", "Body", warm_cache=False)
+
+    assert post.call_args.kwargs["data"]["access_token"] == "environment-token"
+
+
+def test_create_page_requires_a_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("TELEGRAPH_API_TOKEN", raising=False)
+    with pytest.raises(TelegraphTokenError):
+        create_page("Title", "Body", warm_cache=False)
+
+
+def test_create_page_reads_markdown_path_and_removes_duplicate_title_heading(tmp_path: Path) -> None:
+    markdown_path = tmp_path / "article.md"
+    markdown_path.write_text("\n\n# Final title\n\nBody", encoding="utf-8")
+    with unittest.mock.patch.object(telegraph_module.requests, "post", return_value=_success_response()) as post:
+        create_page("Final title", markdown_path, access_token="token", warm_cache=False)
+
+    payload = post.call_args.kwargs["data"]
+    assert json.loads(payload["content"]) == [{"tag": "p", "children": ["Body"]}]
+
+
+def test_create_account_posts_account_details() -> None:
+    with unittest.mock.patch.object(
+        telegraph_module.requests, "post", return_value=_account_response()
+    ) as post:
+        token = create_account(
+            "short-name",
+            author_name="Author",
+            author_url="https://example.com/author",
+            request_timeout=9,
+        )
+
+    assert token == "new-token"
+    post.assert_called_once_with(
+        "https://api.telegra.ph/createAccount",
+        data={
+            "short_name": "short-name",
+            "author_name": "Author",
+            "author_url": "https://example.com/author",
+        },
+        timeout=9,
+    )
+
+
+def test_create_account_rejects_missing_token_in_response() -> None:
+    with (
+        unittest.mock.patch.object(
+            telegraph_module.requests, "post", return_value=FakeResponse(200, {"ok": True, "result": {}})
+        ),
+        pytest.raises(TelegraphAPIError),
+    ):
+        create_account("short-name")
+
+
 def test_create_page_retries_server_error(monkeypatch: pytest.MonkeyPatch) -> None:
     responses = [FakeResponse(500, {}), _success_response()]
     with unittest.mock.patch.object(telegraph_module.requests, "post", side_effect=responses):
         sleep = unittest.mock.Mock()
         monkeypatch.setattr(telegraph_module.time, "sleep", sleep)
-        result = create_page("token", "Title", "Body", retry_attempts=2, warm_cache=False)
+        result = create_page("Title", "Body", access_token="token", retry_attempts=2, warm_cache=False)
 
     assert result == "https://telegra.ph/page"
     sleep.assert_called_once_with(2.0)
@@ -100,7 +169,7 @@ def test_create_page_retries_unsuccessful_api_response() -> None:
         unittest.mock.patch.object(telegraph_module.requests, "post", side_effect=responses),
         unittest.mock.patch.object(telegraph_module.time, "sleep"),
     ):
-        result = create_page("token", "Title", "Body", retry_attempts=2, warm_cache=False)
+        result = create_page("Title", "Body", access_token="token", retry_attempts=2, warm_cache=False)
 
     assert result == "https://telegra.ph/page"
 
@@ -112,7 +181,7 @@ def test_create_page_raises_after_api_retries() -> None:
         unittest.mock.patch.object(telegraph_module.time, "sleep"),
         pytest.raises(TelegraphAPIError) as exc_info,
     ):
-        create_page("token", "Title", "Body", retry_attempts=2, warm_cache=False)
+        create_page("Title", "Body", access_token="token", retry_attempts=2, warm_cache=False)
 
     assert exc_info.value.data == {"ok": False, "error": "permanent"}
 
@@ -122,7 +191,7 @@ def test_create_page_raises_for_final_server_error() -> None:
         unittest.mock.patch.object(telegraph_module.requests, "post", return_value=FakeResponse(500, {})),
         pytest.raises(requests.HTTPError),
     ):
-        create_page("token", "Title", "Body", retry_attempts=2, warm_cache=False)
+        create_page("Title", "Body", access_token="token", retry_attempts=2, warm_cache=False)
 
 
 def test_warm_telegraph_cache_ignores_request_errors() -> None:

--- a/src/lobstersgram/main.py
+++ b/src/lobstersgram/main.py
@@ -69,11 +69,12 @@ def build_item_message(item: Item) -> tuple[str, dict[str, str]]:
     )
     telegraph_title = extracted_title if extracted_title and extracted_title != final_url else item.title
     telegraph_url = create_page(
-        access_token=config.TELEGRAPH_ACCESS_TOKEN,
         title=telegraph_title,
         content_markdown=content_markdown,
         fallback_text=fallback_text,
         source_url=final_url,
+        author_name="Source",
+        access_token=config.TELEGRAPH_ACCESS_TOKEN,
         request_timeout=config.REQUEST_TIMEOUT,
         retry_attempts=config.TELEGRAPH_RETRY_ATTEMPTS,
     )

--- a/uv.lock
+++ b/uv.lock
@@ -456,6 +456,7 @@ source = { editable = "packages/markdown-this" }
 dependencies = [
     { name = "beautifulsoup4" },
     { name = "markdownify" },
+    { name = "pyyaml" },
     { name = "readability-lxml" },
     { name = "requests" },
 ]
@@ -464,6 +465,7 @@ dependencies = [
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.14.3" },
     { name = "markdownify", specifier = ">=1.2.2" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "readability-lxml", specifier = ">=0.8.4.1" },
     { name = "requests", specifier = ">=2.32.5" },
 ]
@@ -499,12 +501,14 @@ version = "0.1.1"
 source = { editable = "packages/md-to-telegraph" }
 dependencies = [
     { name = "mistletoe" },
+    { name = "pyyaml" },
     { name = "requests" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "mistletoe", specifier = ">=1.5.1" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "requests", specifier = ">=2.32.5" },
 ]
 
@@ -641,6 +645,52 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -451,7 +451,7 @@ wheels = [
 
 [[package]]
 name = "markdown-this"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "packages/markdown-this" }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary
- add `md-to-telegraph create-account`
- print `TELEGRAPH_API_TOKEN=...` without publishing a page
- support short name, author metadata, timeout, and retries
- document `export $(...)` and `.bashrc` usage

## Verification
- `202 passed`
- 100% coverage
- Ruff clean

This PR is stacked on #67 and should be reviewed after it.