### PR TITLE
Preserve declared front matter titles

### DIFF
--- a/packages/markdown-this/src/markdown_this/extractor.py
+++ b/packages/markdown-this/src/markdown_this/extractor.py
@@ -45,10 +45,11 @@ def _finalize_content(
 ) -> tuple[str, str, str, str]:
     """Normalize extracted Markdown and derive its fallback text and intro."""
     front_matter, content_markdown = split_front_matter(markdown.strip())
-    content_metadata = {**front_matter, **(metadata or {}), "title": title}
+    resolved_title = front_matter.get("title") or title
+    content_metadata = {**front_matter, **(metadata or {}), "title": resolved_title}
     content_fallback = fallback_text if fallback_text is not None else markdown_to_text(content_markdown)
     intro = extract_intro(content_markdown, content_fallback, intro_min_length)
-    return title, add_front_matter(content_markdown, content_metadata), content_fallback, intro
+    return resolved_title, add_front_matter(content_markdown, content_metadata), content_fallback, intro
 
 
 def _is_http_url(source: str) -> bool:

--- a/packages/markdown-this/tests/test_special_urls.py
+++ b/packages/markdown-this/tests/test_special_urls.py
@@ -335,6 +335,29 @@ def test_extract_main_content_handles_special_and_generic_paths() -> None:
         assert result[2] == "Repo\n\nRepo content"
 
     with (
+        unittest.mock.patch(
+            "markdown_this.extractor.fetch_github_blob_markdown",
+            return_value=("owner/repo/README.md", "---\ntitle: Declared title\n---\n\nREADME content"),
+        ),
+    ):
+        result = extractor_module.extract_main_content("https://github.com/owner/repo/blob/main/README.md")
+        metadata, body = extractor_module.split_front_matter(result[1])
+        assert result[0] == "Declared title"
+        assert metadata["title"] == "Declared title"
+        assert body == "README content"
+
+    with (
+        unittest.mock.patch("markdown_this.extractor.fetch_github_blob_markdown", return_value=None),
+        unittest.mock.patch(
+            "markdown_this.extractor.fetch_github_readme",
+            return_value=("owner/repo", "---\ntitle: Declared README title\n---\n\nREADME content"),
+        ),
+    ):
+        result = extractor_module.extract_main_content("https://github.com/owner/repo")
+        assert result[0] == "Declared README title"
+        assert result[2] == "README content"
+
+    with (
         unittest.mock.patch("markdown_this.extractor.fetch_github_blob_markdown", return_value=None),
         unittest.mock.patch("markdown_this.extractor.fetch_github_readme", return_value=None),
         unittest.mock.patch("markdown_this.extractor.fetch_arxiv_abstract", return_value=("Paper", "Paper content")),


### PR DESCRIPTION
## Summary
- preserve a Markdown document's front-matter `title` over GitHub fallback titles
- apply the behavior to GitHub README and Markdown blob extraction
- add regression coverage for both paths

## Verification
- `106 passed` in `markdown-this` tests
- 100% package coverage
- Ruff clean

Addresses review discussion `discussion_r3725670450` from PR #67.