### PR TITLE
Preserve article images through Markdown metadata

### DIFF
--- a/packages/markdown-this/pyproject.toml
+++ b/packages/markdown-this/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "markdown-this"
-version = "0.1.1"
+version = "0.1.2"
 description = "Extract web pages and supported special URLs as Markdown"
 readme = "README.md"
 authors = [{ name = "Martín Gaitán", email = "gaitan@gmail.com" }]

--- a/packages/markdown-this/pyproject.toml
+++ b/packages/markdown-this/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "markdown-this"
-version = "0.1.2"
+version = "0.1.3"
 description = "Extract web pages and supported special URLs as Markdown"
 readme = "README.md"
 authors = [{ name = "Martín Gaitán", email = "gaitan@gmail.com" }]

--- a/packages/markdown-this/src/markdown_this/extractor.py
+++ b/packages/markdown-this/src/markdown_this/extractor.py
@@ -92,7 +92,7 @@ def _extract_html_content(  # noqa: PLR0913
     extracted_markdown = _normalize_markdown_links(extracted_markdown)
     extracted_markdown = _make_markdown_links_absolute(extracted_markdown, base_url)
     fallback_text = BeautifulSoup(content_html_for_markdown, "html.parser").get_text(separator="\n").strip()
-    metadata = extract_html_metadata(content_html)
+    metadata = extract_html_metadata(content_html, base_url)
     if source_url:
         metadata["url"] = source_url
     return _finalize_content(title, extracted_markdown, fallback_text, intro_min_length, metadata)

--- a/packages/markdown-this/src/markdown_this/extractor.py
+++ b/packages/markdown-this/src/markdown_this/extractor.py
@@ -45,10 +45,11 @@ def _finalize_content(
 ) -> tuple[str, str, str, str]:
     """Normalize extracted Markdown and derive its fallback text and intro."""
     front_matter, content_markdown = split_front_matter(markdown.strip())
-    content_metadata = {**front_matter, **(metadata or {}), "title": title}
+    resolved_title = front_matter.get("title") or title
+    content_metadata = {**front_matter, **(metadata or {}), "title": resolved_title}
     content_fallback = fallback_text if fallback_text is not None else markdown_to_text(content_markdown)
     intro = extract_intro(content_markdown, content_fallback, intro_min_length)
-    return title, add_front_matter(content_markdown, content_metadata), content_fallback, intro
+    return resolved_title, add_front_matter(content_markdown, content_metadata), content_fallback, intro
 
 
 def _is_http_url(source: str) -> bool:

--- a/packages/markdown-this/src/markdown_this/metadata.py
+++ b/packages/markdown-this/src/markdown_this/metadata.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from urllib.parse import urljoin, urlparse
 
 import yaml
 from bs4 import BeautifulSoup
 
-METADATA_FIELDS = ("title", "author", "url", "date")
+METADATA_FIELDS = ("title", "author", "url", "date", "image")
 
 
 def split_front_matter(markdown: str) -> tuple[dict[str, str], str]:
@@ -45,8 +46,8 @@ def add_front_matter(markdown: str, metadata: Mapping[str, str]) -> str:
     return f"---\n{header}\n---\n\n{markdown}" if markdown else f"---\n{header}\n---"
 
 
-def extract_html_metadata(content_html: str) -> dict[str, str]:
-    """Extract common author, canonical URL, and publication date metadata."""
+def extract_html_metadata(content_html: str, base_url: str = "") -> dict[str, str]:
+    """Extract common author, canonical URL, date, and primary image metadata."""
     soup = BeautifulSoup(content_html, "html.parser")
 
     def first_meta(*queries: dict[str, str]) -> str:
@@ -67,10 +68,25 @@ def extract_html_metadata(content_html: str) -> dict[str, str]:
         {"name": "date"},
         {"itemprop": "datePublished"},
     )
+    image = first_meta(
+        {"property": "og:image"},
+        {"property": "og:image:url"},
+        {"name": "twitter:image"},
+        {"property": "twitter:image"},
+        {"itemprop": "image"},
+    )
+    image = urljoin(base_url, image) if image else ""
+    parsed_image = urlparse(image)
+    if parsed_image.scheme not in {"http", "https"} or not parsed_image.netloc:
+        image = ""
     canonical = soup.find("link", rel=lambda value: value and "canonical" in value)
     url = str(canonical.get("href", "")).strip() if canonical else ""
     url = url or first_meta({"property": "og:url"})
     if not date:
         time_tag = soup.find("time", attrs={"datetime": True})
         date = str(time_tag["datetime"]).strip() if time_tag else ""
-    return {field: value for field, value in (("author", author), ("url", url), ("date", date)) if value}
+    return {
+        field: value
+        for field, value in (("author", author), ("url", url), ("date", date), ("image", image))
+        if value
+    }

--- a/packages/markdown-this/tests/test_extractor.py
+++ b/packages/markdown-this/tests/test_extractor.py
@@ -54,6 +54,7 @@ def test_extract_main_content_emits_html_metadata() -> None:
         '<meta name="author" content="Author">'
         '<link rel="canonical" href="https://example.com/article">'
         '<meta property="article:published_time" content="2026-08-06">'
+        '<meta property="og:image" content="https://cdn.example.com/hero.jpg">'
         "<p>Raw HTML</p>"
     )
     with unittest.mock.patch.object(extractor_module, "Document", return_value=_document()):
@@ -65,4 +66,5 @@ def test_extract_main_content_emits_html_metadata() -> None:
         "author": "Author",
         "url": "https://example.com/article",
         "date": "2026-08-06",
+        "image": "https://cdn.example.com/hero.jpg",
     }

--- a/packages/markdown-this/tests/test_metadata.py
+++ b/packages/markdown-this/tests/test_metadata.py
@@ -13,6 +13,7 @@ def test_front_matter_round_trip() -> None:
             "author": "Author",
             "url": "https://example.com/article",
             "date": "2026-08-06",
+            "image": "https://example.com/image.jpg",
         },
     )
 
@@ -22,6 +23,7 @@ def test_front_matter_round_trip() -> None:
         "author": "Author",
         "url": "https://example.com/article",
         "date": "2026-08-06",
+        "image": "https://example.com/image.jpg",
     }
     assert body == "Body"
 
@@ -57,8 +59,16 @@ def test_extract_html_metadata_reads_meta_tags_and_canonical_url() -> None:
 
 
 def test_extract_html_metadata_reads_open_graph_and_time_fallback() -> None:
-    html = '<meta property="og:url" content="https://example.com"><time datetime="2026-08-05">Yesterday</time>'
-    assert extract_html_metadata(html) == {"url": "https://example.com", "date": "2026-08-05"}
+    html = (
+        '<meta property="og:url" content="https://example.com">'
+        '<meta property="og:image" content="/images/hero.jpg">'
+        '<time datetime="2026-08-05">Yesterday</time>'
+    )
+    assert extract_html_metadata(html, "https://example.com/article") == {
+        "url": "https://example.com",
+        "date": "2026-08-05",
+        "image": "https://example.com/images/hero.jpg",
+    }
 
 
 def test_extract_html_metadata_returns_empty_for_missing_values() -> None:

--- a/packages/markdown-this/tests/test_special_urls.py
+++ b/packages/markdown-this/tests/test_special_urls.py
@@ -335,6 +335,29 @@ def test_extract_main_content_handles_special_and_generic_paths() -> None:
         assert result[2] == "Repo\n\nRepo content"
 
     with (
+        unittest.mock.patch(
+            "markdown_this.extractor.fetch_github_blob_markdown",
+            return_value=("owner/repo/README.md", "---\ntitle: Declared title\n---\n\nREADME content"),
+        ),
+    ):
+        result = extractor_module.extract_main_content("https://github.com/owner/repo/blob/main/README.md")
+        metadata, body = extractor_module.split_front_matter(result[1])
+        assert result[0] == "Declared title"
+        assert metadata["title"] == "Declared title"
+        assert body == "README content"
+
+    with (
+        unittest.mock.patch("markdown_this.extractor.fetch_github_blob_markdown", return_value=None),
+        unittest.mock.patch(
+            "markdown_this.extractor.fetch_github_readme",
+            return_value=("owner/repo", "---\ntitle: Declared README title\n---\n\nREADME content"),
+        ),
+    ):
+        result = extractor_module.extract_main_content("https://github.com/owner/repo")
+        assert result[0] == "Declared README title"
+        assert result[2] == "README content"
+
+    with (
         unittest.mock.patch("markdown_this.extractor.fetch_github_blob_markdown", return_value=None),
         unittest.mock.patch("markdown_this.extractor.fetch_github_readme", return_value=None),
         unittest.mock.patch("markdown_this.extractor.fetch_arxiv_abstract", return_value=("Paper", "Paper content")),

--- a/packages/md-to-telegraph/pyproject.toml
+++ b/packages/md-to-telegraph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "md-to-telegraph"
-version = "0.1.1"
+version = "0.1.2"
 description = "Convert Markdown to Telegraph DOM nodes"
 readme = "README.md"
 authors = [{ name = "Martín Gaitán", email = "gaitan@gmail.com" }]

--- a/packages/md-to-telegraph/pyproject.toml
+++ b/packages/md-to-telegraph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "md-to-telegraph"
-version = "0.1.2"
+version = "0.1.3"
 description = "Convert Markdown to Telegraph DOM nodes"
 readme = "README.md"
 authors = [{ name = "Martín Gaitán", email = "gaitan@gmail.com" }]

--- a/packages/md-to-telegraph/src/md_to_telegraph/md_to_dom.py
+++ b/packages/md-to-telegraph/src/md_to_telegraph/md_to_dom.py
@@ -147,3 +147,23 @@ def content_to_telegraph(markdown_text: str, fallback_text: str = "") -> NodeLis
         return [{"tag": "p", "children": [paragraph]} for paragraph in paragraphs[:2000]]
 
     return [{"tag": "p", "children": ["(No content extracted)"]}]
+
+
+def prepend_image(nodes: NodeList, image_url: str) -> NodeList:
+    """Prepend a metadata image unless the same image is already in the content."""
+    if not image_url or _contains_image(nodes, image_url):
+        return nodes
+    return [{"tag": "img", "attrs": {"src": image_url}}, *nodes]
+
+
+def _contains_image(nodes: NodeList, image_url: str) -> bool:
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        attrs = node.get("attrs")
+        if isinstance(attrs, dict) and attrs.get("src") == image_url and node.get("tag") == "img":
+            return True
+        children = node.get("children")
+        if isinstance(children, list) and _contains_image(children, image_url):
+            return True
+    return False

--- a/packages/md-to-telegraph/src/md_to_telegraph/metadata.py
+++ b/packages/md-to-telegraph/src/md_to_telegraph/metadata.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping
 
 import yaml
 
-METADATA_FIELDS = ("title", "author", "url", "date")
+METADATA_FIELDS = ("title", "author", "url", "date", "image")
 
 
 def split_front_matter(markdown: str) -> tuple[dict[str, str], str]:

--- a/packages/md-to-telegraph/src/md_to_telegraph/telegraph.py
+++ b/packages/md-to-telegraph/src/md_to_telegraph/telegraph.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import requests
 
 from md_to_telegraph.markdown import extract_leading_title, strip_leading_title_heading
-from md_to_telegraph.md_to_dom import content_to_telegraph
+from md_to_telegraph.md_to_dom import content_to_telegraph, prepend_image
 from md_to_telegraph.metadata import split_front_matter
 
 logger = logging.getLogger(__name__)
@@ -138,7 +138,7 @@ def create_page(  # noqa: PLR0913
     markdown = strip_leading_title_heading(markdown, page_title)
     source_url = source_url or metadata.get("url", "")
     author_name = author_name or metadata.get("author", "")
-    nodes = content_to_telegraph(markdown, fallback_text)
+    nodes = prepend_image(content_to_telegraph(markdown, fallback_text), metadata.get("image", ""))
     payload: dict[str, object] = {
         "access_token": token,
         "title": page_title,

--- a/packages/md-to-telegraph/tests/test_md_to_dom.py
+++ b/packages/md-to-telegraph/tests/test_md_to_dom.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from md_to_telegraph import content_to_telegraph, md_to_telegraph
+from md_to_telegraph.md_to_dom import prepend_image
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -357,6 +358,18 @@ def test_content_to_telegraph_uses_fallback_paragraphs() -> None:
 
 def test_content_to_telegraph_uses_empty_content_placeholder() -> None:
     assert content_to_telegraph("", "   \n  ") == [{"tag": "p", "children": ["(No content extracted)"]}]
+
+
+def test_prepend_image_adds_metadata_image() -> None:
+    assert prepend_image([{"tag": "p", "children": ["Body"]}], "https://example.com/hero.jpg") == [
+        {"tag": "img", "attrs": {"src": "https://example.com/hero.jpg"}},
+        {"tag": "p", "children": ["Body"]},
+    ]
+
+
+def test_prepend_image_does_not_duplicate_content_image() -> None:
+    nodes = md_to_telegraph("![Hero](https://example.com/hero.jpg)")
+    assert prepend_image(nodes, "https://example.com/hero.jpg") == nodes
 
 
 def test_nbsp_only_paragraph_is_skipped() -> None:

--- a/packages/md-to-telegraph/tests/test_metadata.py
+++ b/packages/md-to-telegraph/tests/test_metadata.py
@@ -5,13 +5,14 @@ from md_to_telegraph import split_front_matter
 
 def test_split_front_matter_reads_supported_fields() -> None:
     metadata, body = split_front_matter(
-        "---\ntitle: Title\nauthor: Author\nurl: https://example.com\ndate: 2026-08-06\n---\n\nBody"
+        "---\ntitle: Title\nauthor: Author\nurl: https://example.com\ndate: 2026-08-06\nimage: https://example.com/image.jpg\n---\n\nBody"
     )
     assert metadata == {
         "title": "Title",
         "author": "Author",
         "url": "https://example.com",
         "date": "2026-08-06",
+        "image": "https://example.com/image.jpg",
     }
     assert body == "Body"
 

--- a/packages/md-to-telegraph/tests/test_telegraph.py
+++ b/packages/md-to-telegraph/tests/test_telegraph.py
@@ -121,7 +121,10 @@ def test_create_page_reads_markdown_path_and_removes_duplicate_title_heading(tmp
 
 
 def test_create_page_reads_front_matter_defaults() -> None:
-    markdown = "---\ntitle: Front matter title\nauthor: Author\nurl: https://example.com\ndate: 2026-08-06\n---\n\nBody"
+    markdown = (
+        "---\ntitle: Front matter title\nauthor: Author\nurl: https://example.com\n"
+        "date: 2026-08-06\nimage: https://example.com/hero.jpg\n---\n\nBody"
+    )
     with unittest.mock.patch.object(telegraph_module.requests, "post", return_value=_success_response()) as post:
         create_page(content_markdown=markdown, access_token="token", warm_cache=False)
 
@@ -129,7 +132,33 @@ def test_create_page_reads_front_matter_defaults() -> None:
     assert payload["title"] == "Front matter title"
     assert payload["author_name"] == "Author"
     assert payload["author_url"] == "https://example.com"
-    assert json.loads(payload["content"]) == [{"tag": "p", "children": ["Body"]}]
+    assert json.loads(payload["content"]) == [
+        {"tag": "img", "attrs": {"src": "https://example.com/hero.jpg"}},
+        {"tag": "p", "children": ["Body"]},
+    ]
+
+
+def test_create_page_does_not_duplicate_front_matter_image() -> None:
+    markdown = "---\nimage: https://example.com/hero.jpg\n---\n\n![Hero](https://example.com/hero.jpg)"
+    with unittest.mock.patch.object(telegraph_module.requests, "post", return_value=_success_response()) as post:
+        create_page(
+            title="Title",
+            content_markdown=markdown,
+            access_token="token",
+            warm_cache=False,
+        )
+
+    assert json.loads(post.call_args.kwargs["data"]["content"]) == [
+        {
+            "tag": "p",
+            "children": [
+                {
+                    "tag": "img",
+                    "attrs": {"src": "https://example.com/hero.jpg", "alt": ["Hero"]},
+                }
+            ],
+        }
+    ]
 
 
 def test_create_page_explicit_values_override_front_matter() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -451,7 +451,7 @@ wheels = [
 
 [[package]]
 name = "markdown-this"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "packages/markdown-this" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -497,7 +497,7 @@ wheels = [
 
 [[package]]
 name = "md-to-telegraph"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "packages/md-to-telegraph" }
 dependencies = [
     { name = "mistletoe" },

--- a/uv.lock
+++ b/uv.lock
@@ -451,7 +451,7 @@ wheels = [
 
 [[package]]
 name = "markdown-this"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "packages/markdown-this" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -497,7 +497,7 @@ wheels = [
 
 [[package]]
 name = "md-to-telegraph"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "packages/md-to-telegraph" }
 dependencies = [
     { name = "mistletoe" },


### PR DESCRIPTION
Closes #70

Extract the primary article image from Open Graph/Twitter metadata, serialize it in YAML front matter, and have md-to-telegraph publish it without duplicating an image already present in the Markdown.

Also bumps both packages to 0.1.3. Tests pass with 100% coverage.