### PR TITLE
Fix markdown-web FastAPI Cloud entrypoint

### DIFF
--- a/packages/markdown-web/main.py
+++ b/packages/markdown-web/main.py
@@ -1,0 +1,5 @@
+"""FastAPI Cloud entrypoint."""
+
+from markdown_web.app import app
+
+__all__ = ["app"]


### PR DESCRIPTION
Expose a root main.py shim so FastAPI Cloud can discover the application during production startup.