### PR TITLE
Improve Page to Telegraph flow

### DIFF
--- a/packages/markdown-web/README.md
+++ b/packages/markdown-web/README.md
@@ -1,4 +1,4 @@
-# markdown-web
+# Page to Telegraph
 
 Minimal FastAPI service around [`markdown-this`](../markdown-this/) and
 [`md-to-telegraph`](../md-to-telegraph/).
@@ -21,6 +21,9 @@ The URL is a path, in the style of `r.jina.ai`:
 curl http://127.0.0.1:8000/md/https://example.com/article
 curl -L http://127.0.0.1:8000/t/https://example.com/article
 ```
+
+GET `/t/<url>` reuses the Telegraph page already created for that source URL
+by this running service. POST `/t` always publishes the supplied content.
 
 The target URL should be URL-encoded when it contains characters that have a
 meaning to the web server. POST endpoints accept JSON with a URL, raw HTML, or

--- a/packages/markdown-web/src/markdown_web/app.py
+++ b/packages/markdown-web/src/markdown_web/app.py
@@ -23,7 +23,7 @@ from markdown_web.service import (
     telegraph_tokens,
 )
 
-app = FastAPI(title="markdown-web", description="Extract Markdown and publish it to Telegraph")
+app = FastAPI(title="Page to Telegraph", description="Extract Markdown and publish it to Telegraph")
 app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["POST"], allow_headers=["*"])
 PACKAGE_DIR = Path(__file__).resolve().parent
 templates = Jinja2Templates(directory=str(PACKAGE_DIR / "templates"))
@@ -109,10 +109,15 @@ async def markdown_from_post(request: Request) -> PlainTextResponse:
 @app.get("/t/{url:path}")
 def telegraph_from_url(url: str, request: Request) -> RedirectResponse:
     try:
-        target = publish_content(_source_request_from_path(url, request))
+        source_url = _path_source(url, request)
+        target = publish_content(SourceRequest(url=source_url), cache_key=source_url)
     except Exception as exc:
         raise _handle_source_error(exc) from exc
-    return RedirectResponse(target, status_code=303)
+    return RedirectResponse(
+        target,
+        status_code=303,
+        headers={"Cache-Control": "public, max-age=86400"},
+    )
 
 
 @app.post("/t")

--- a/packages/markdown-web/src/markdown_web/service.py
+++ b/packages/markdown-web/src/markdown_web/service.py
@@ -13,8 +13,8 @@ from md_to_telegraph import create_account, create_page
 
 from markdown_web.schemas import SourceMetadata, SourceRequest
 
-DEFAULT_ACCOUNT_NAME = "markdown-web"
-DEFAULT_AUTHOR_NAME = "markdown-web"
+DEFAULT_ACCOUNT_NAME = "page-to-telegraph"
+DEFAULT_AUTHOR_NAME = "page-to-telegraph"
 
 
 class SourceError(ValueError):
@@ -99,6 +99,8 @@ class BookmarkletTokenStore:
 
 telegraph_tokens = TelegraphTokenStore()
 bookmarklet_tokens = BookmarkletTokenStore()
+published_urls: dict[str, str] = {}
+published_urls_lock = threading.Lock()
 
 
 def _require_source(request: SourceRequest) -> str:
@@ -138,7 +140,7 @@ def prepare_content(request: SourceRequest) -> PreparedContent:
     return PreparedContent(title=title, markdown=markdown, fallback_text=fallback_text, metadata=metadata)
 
 
-def publish_content(request: SourceRequest, bookmarklet_key: str | None = None) -> str:
+def _publish_content(request: SourceRequest, bookmarklet_key: str | None = None) -> str:
     """Publish request content to Telegraph and return its public URL."""
     prepared = prepare_content(request)
     token = request.access_token or bookmarklet_tokens.resolve(bookmarklet_key)
@@ -149,6 +151,23 @@ def publish_content(request: SourceRequest, bookmarklet_key: str | None = None) 
         fallback_text=prepared.fallback_text,
         access_token=token,
     )
+
+
+def publish_content(
+    request: SourceRequest,
+    bookmarklet_key: str | None = None,
+    cache_key: str | None = None,
+) -> str:
+    """Publish content, optionally reusing the Telegraph page for a source URL."""
+    if not cache_key:
+        return _publish_content(request, bookmarklet_key)
+
+    with published_urls_lock:
+        if target := published_urls.get(cache_key):
+            return target
+        target = _publish_content(request, bookmarklet_key)
+        published_urls[cache_key] = target
+        return target
 
 
 def require_bookmarklet_token(key: str | None) -> str:

--- a/packages/markdown-web/src/markdown_web/static/styles.css
+++ b/packages/markdown-web/src/markdown_web/static/styles.css
@@ -7,6 +7,8 @@
 
 * { box-sizing: border-box; }
 
+[hidden] { display: none !important; }
+
 body { margin: 0; }
 
 a { color: inherit; }
@@ -43,7 +45,8 @@ h1 {
   font-weight: 400;
 }
 
-.source-form { display: flex; gap: 18px; align-items: center; }
+.source-form { display: block; }
+.source-entry { display: flex; gap: 18px; align-items: center; }
 
 input, textarea {
   width: 100%;
@@ -74,8 +77,7 @@ input:focus, textarea:focus { border-bottom-color: #333; }
 .button-primary { background: #333; color: #fff; }
 .button:hover, .bookmarklet:hover { opacity: .7; }
 
-.result-heading, .result-actions { display: flex; align-items: center; justify-content: space-between; gap: 16px; }
-.result-heading { margin-bottom: 18px; }
+.result-toolbar { display: flex; align-items: center; justify-content: space-between; gap: 16px; margin-bottom: 18px; }
 .source-label { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
 .text-button { border: 0; padding: 0; background: none; cursor: pointer; }
@@ -90,12 +92,13 @@ textarea {
   line-height: 1.6;
 }
 
-.result-actions { justify-content: flex-end; margin-top: 18px; }
+.result-actions { display: flex; align-items: center; gap: 12px; }
 .status { min-height: 1.5em; color: #777; font-size: 14px; }
 .status.error { color: #a33; }
 
 .footer { max-width: 820px; margin: 0 auto; padding: 0 28px 28px; }
 .footer a { margin: 0 4px; }
+.result .text-button { margin-top: 12px; }
 
 .lede { color: #777; font-size: 18px; }
 .bookmarklet-form { display: grid; gap: 14px; max-width: 460px; margin-top: 36px; }
@@ -110,7 +113,8 @@ textarea {
   .page { padding: 20px 20px 48px; }
   .masthead { margin-bottom: 64px; }
   h1 { font-size: 28px; }
-  .source-form { display: block; }
-  .source-form .button { margin-top: 22px; }
+  .source-entry { display: block; }
+  .source-entry .button { margin-top: 22px; }
+  .result-toolbar { align-items: flex-start; flex-direction: column; }
   .footer { padding: 0 20px 20px; }
 }

--- a/packages/markdown-web/src/markdown_web/templates/bookmarklet.html
+++ b/packages/markdown-web/src/markdown_web/templates/bookmarklet.html
@@ -3,13 +3,13 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Bookmarklet | markdown-web</title>
-    <link rel="stylesheet" href="/static/styles.css?v=2">
+    <title>Bookmarklets | Page to Telegraph</title>
+    <link rel="stylesheet" href="/static/styles.css?v=3">
   </head>
   <body>
     <main class="page narrow">
       <header class="masthead">
-        <a class="wordmark" href="/">markdown-web</a>
+        <a class="wordmark" href="/">Page to Telegraph</a>
       </header>
       <h1>Save the bookmarklets</h1>
       {% if not bookmarklets %}

--- a/packages/markdown-web/src/markdown_web/templates/index.html
+++ b/packages/markdown-web/src/markdown_web/templates/index.html
@@ -3,58 +3,62 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>markdown-web</title>
-    <link rel="stylesheet" href="/static/styles.css?v=2">
+    <title>Page to Telegraph</title>
+    <link rel="stylesheet" href="/static/styles.css?v=3">
   </head>
   <body>
     <main class="page">
       <header class="masthead">
-        <a class="wordmark" href="/">markdown-web</a>
+        <a class="wordmark" href="/">Page to Telegraph</a>
         <a class="quiet-link" href="/bookmarklet/">bookmarklet</a>
       </header>
 
       <section class="workspace" aria-labelledby="page-title">
-        <h1 id="page-title">Turn any page into Markdown</h1>
+        <h1 id="page-title">Turn any page into Markdown or publish it to Telegraph</h1>
         <form id="process-form" class="source-form">
-          <label class="sr-only" for="source-url">URL</label>
-          <input id="source-url" name="url" type="url" placeholder="Paste a URL" required autofocus>
-          <button class="button button-primary" type="submit">Process</button>
-        </form>
+          <div id="source-entry" class="source-entry">
+            <label class="sr-only" for="source-url">URL</label>
+            <input id="source-url" name="url" type="url" placeholder="Paste a URL" required autofocus>
+            <button id="submit-button" class="button button-primary" type="submit">Process</button>
+          </div>
 
-        <section id="result" class="result" hidden>
-          <div class="result-heading">
-            <span id="result-source" class="source-label"></span>
+          <section id="result" class="result" hidden>
+            <div class="result-toolbar">
+              <span id="result-source" class="source-label"></span>
+              <div class="result-actions">
+                <button id="copy-button" class="button button-secondary" type="button">Copy</button>
+                <button id="submit-publish" class="button button-primary" type="submit">Publish</button>
+              </div>
+            </div>
+            <label class="sr-only" for="markdown-output">Markdown</label>
+            <textarea id="markdown-output" spellcheck="false"></textarea>
             <button id="edit-button" class="text-button" type="button">Edit URL</button>
-          </div>
-          <label class="sr-only" for="markdown-output">Markdown</label>
-          <textarea id="markdown-output" spellcheck="false"></textarea>
-          <div class="result-actions">
-            <button id="copy-button" class="button button-secondary" type="button">Copy</button>
-            <button id="publish-button" class="button button-primary" type="button">Publish</button>
-          </div>
+          </section>
           <p id="status" class="status" role="status"></p>
-        </section>
+        </form>
       </section>
     </main>
 
     <footer class="footer">
       <span>Try</span>
-      <a href="/md/https://example.com">/md</a>
+      <a href="/md/https://example.com">/md/&lt;url&gt;</a>
       <span>for raw Markdown</span>
       <span>or</span>
-      <a href="/t/https://example.com">/t</a>
+      <a href="/t/https://example.com">/t/&lt;url&gt;</a>
       <span>for Telegraph.</span>
       <a href="https://github.com/mgaitan/lobstersgram/tree/main/packages/markdown-web">GitHub</a>
     </footer>
 
     <script>
       const form = document.querySelector("#process-form");
+      const sourceEntry = document.querySelector("#source-entry");
       const result = document.querySelector("#result");
       const output = document.querySelector("#markdown-output");
       const sourceInput = document.querySelector("#source-url");
       const sourceLabel = document.querySelector("#result-source");
       const status = document.querySelector("#status");
       let currentUrl = "";
+      let mode = "process";
 
       function setStatus(message, error = false) {
         status.textContent = message;
@@ -63,6 +67,23 @@
 
       form.addEventListener("submit", async (event) => {
         event.preventDefault();
+        if (mode === "publish") {
+          setStatus("Publishing…");
+          try {
+            const response = await fetch("/t", {
+              method: "POST",
+              headers: {"Content-Type": "application/json"},
+              body: JSON.stringify({markdown: output.value, metadata: {url: currentUrl}})
+            });
+            const data = await response.json();
+            if (!response.ok) throw new Error(data.detail || "Publish failed");
+            window.location.href = data.url;
+          } catch (error) {
+            setStatus(error.message, true);
+          }
+          return;
+        }
+
         currentUrl = sourceInput.value.trim();
         setStatus("Processing…");
         try {
@@ -70,8 +91,9 @@
           if (!response.ok) throw new Error(await response.text());
           output.value = await response.text();
           sourceLabel.textContent = currentUrl;
-          form.hidden = true;
+          sourceEntry.hidden = true;
           result.hidden = false;
+          mode = "publish";
           setStatus("");
         } catch (error) {
           setStatus(error.message, true);
@@ -80,7 +102,8 @@
 
       document.querySelector("#edit-button").addEventListener("click", () => {
         result.hidden = true;
-        form.hidden = false;
+        sourceEntry.hidden = false;
+        mode = "process";
         sourceInput.focus();
       });
 
@@ -89,21 +112,6 @@
         setStatus("Copied");
       });
 
-      document.querySelector("#publish-button").addEventListener("click", async () => {
-        setStatus("Publishing…");
-        try {
-          const response = await fetch("/t", {
-            method: "POST",
-            headers: {"Content-Type": "application/json"},
-            body: JSON.stringify({markdown: output.value, metadata: {url: currentUrl}})
-          });
-          const data = await response.json();
-          if (!response.ok) throw new Error(data.detail || "Publish failed");
-          window.location.href = data.url;
-        } catch (error) {
-          setStatus(error.message, true);
-        }
-      });
     </script>
   </body>
 </html>

--- a/packages/markdown-web/tests/test_app.py
+++ b/packages/markdown-web/tests/test_app.py
@@ -15,7 +15,8 @@ def _prepared(markdown: str = "# Title\n\nBody") -> PreparedContent:
 def test_home_and_static_assets() -> None:
     response = client.get("/")
     assert response.status_code == HTTP_200_OK
-    assert "Turn any page into Markdown" in response.text
+    assert "Turn any page into Markdown or publish it to Telegraph" in response.text
+    assert ">markdown-web<" not in response.text
     assert client.get("/static/styles.css").status_code == HTTP_200_OK
 
 
@@ -68,8 +69,13 @@ def test_post_markdown_accepts_raw_html_metadata(monkeypatch: pytest.MonkeyPatch
 def test_post_telegraph_returns_json_and_accepts_bearer_token(monkeypatch: pytest.MonkeyPatch) -> None:
     seen: dict[str, SourceRequest] = {}
 
-    def fake_publish(source: SourceRequest, bookmarklet_key: str | None = None) -> str:
+    def fake_publish(
+        source: SourceRequest,
+        bookmarklet_key: str | None = None,
+        cache_key: str | None = None,
+    ) -> str:
         seen["source"] = source
+        seen["cache_key"] = cache_key
         return "https://telegra.ph/page"
 
     monkeypatch.setattr(app_module, "publish_content", fake_publish)
@@ -86,12 +92,25 @@ def test_post_telegraph_returns_json_and_accepts_bearer_token(monkeypatch: pytes
 
 
 def test_get_telegraph_redirects(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(app_module, "publish_content", lambda source: "https://telegra.ph/page")
+    seen: dict[str, object] = {}
+
+    def fake_publish(
+        source: SourceRequest,
+        bookmarklet_key: str | None = None,
+        cache_key: str | None = None,
+    ) -> str:
+        seen["source"] = source
+        seen["cache_key"] = cache_key
+        return "https://telegra.ph/page"
+
+    monkeypatch.setattr(app_module, "publish_content", fake_publish)
 
     response = client.get("/t/https://example.com/article", follow_redirects=False)
 
     assert response.status_code == HTTP_303_SEE_OTHER
     assert response.headers["location"] == "https://telegra.ph/page"
+    assert response.headers["cache-control"] == "public, max-age=86400"
+    assert seen["cache_key"] == "https://example.com/article"
 
 
 def test_bookmarklet_form_does_not_expose_token(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/markdown-web/tests/test_service.py
+++ b/packages/markdown-web/tests/test_service.py
@@ -74,3 +74,23 @@ def test_publish_content_passes_resolved_token(monkeypatch: pytest.MonkeyPatch) 
 
     assert result == "https://telegra.ph/page"
     assert published["access_token"] == "environment-token"
+
+
+def test_publish_content_reuses_cached_source_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    service.published_urls.clear()
+    calls = 0
+
+    def fake_create_page(**kwargs: object) -> str:
+        nonlocal calls
+        calls += 1
+        return "https://telegra.ph/cached"
+
+    monkeypatch.setenv("TELEGRAPH_API_TOKEN", "environment-token")
+    monkeypatch.setattr(service, "create_page", fake_create_page)
+    source = SourceRequest(markdown="# Title\n\nBody")
+
+    first = service.publish_content(source, cache_key="https://example.com")
+    second = service.publish_content(source, cache_key="https://example.com")
+
+    assert first == second == "https://telegra.ph/cached"
+    assert calls == 1


### PR DESCRIPTION
Remove the technical app name from the UI, update the headline and post-conversion controls, and reuse Telegraph pages for repeated GET /t/{url} requests.