### PR TITLE
Improve Page to Telegraph metadata and flow

### DIFF
--- a/packages/markdown-this/src/markdown_this/metadata.py
+++ b/packages/markdown-this/src/markdown_this/metadata.py
@@ -62,6 +62,8 @@ def extract_html_metadata(content_html: str, base_url: str = "") -> dict[str, st
         {"property": "article:author"},
         {"name": "byline"},
         {"itemprop": "author"},
+        {"property": "og:site_name"},
+        {"name": "publisher"},
     )
     date = first_meta(
         {"property": "article:published_time"},

--- a/packages/markdown-this/tests/test_metadata.py
+++ b/packages/markdown-this/tests/test_metadata.py
@@ -69,5 +69,11 @@ def test_extract_html_metadata_reads_open_graph_and_time_fallback() -> None:
     }
 
 
+def test_extract_html_metadata_uses_site_name_when_author_is_missing() -> None:
+    html = '<meta name="author" content=""><meta property="og:site_name" content="Página|12">'
+
+    assert extract_html_metadata(html) == {"author": "Página|12"}
+
+
 def test_extract_html_metadata_returns_empty_for_missing_values() -> None:
     assert extract_html_metadata("<html></html>") == {}


### PR DESCRIPTION
Remove the technical app name from the UI, improve the post-conversion controls, reuse Telegraph pages for repeated GET /t/{url} requests, and use the source site name as the Telegraph author when an article has no individual author.