### PR TITLE
Filter advertising with readability heuristics

### DIFF
--- a/packages/markdown-this/src/markdown_this/extractor.py
+++ b/packages/markdown-this/src/markdown_this/extractor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import urllib.parse
 from logging import getLogger
 from pathlib import Path
@@ -27,6 +28,11 @@ from markdown_this.markdown import (
 from markdown_this.metadata import add_front_matter, extract_html_metadata, split_front_matter
 
 logger = getLogger(__name__)
+
+AD_NEGATIVE_KEYWORDS = re.compile(
+    r"(?:^|[-_ ])(?:ad|ads|advert|advertising|advertisement|sponsor|sponsored|promo)(?:$|[-_ ])",
+    re.IGNORECASE,
+)
 
 
 class ContentDownloadError(RuntimeError):
@@ -75,10 +81,11 @@ def _extract_html_content(  # noqa: PLR0913
     if not content_html:
         raise ContentDownloadError
 
+    metadata = extract_html_metadata(content_html, base_url)
     content_html_for_markdown = ""
     title = source_label
     try:
-        document = Document(content_html)
+        document = Document(content_html, negative_keywords=AD_NEGATIVE_KEYWORDS)
         content_html_for_markdown = document.summary() or ""
         title = document.title() or source_label
     except Exception as exc:  # noqa: BLE001
@@ -92,7 +99,6 @@ def _extract_html_content(  # noqa: PLR0913
     extracted_markdown = _normalize_markdown_links(extracted_markdown)
     extracted_markdown = _make_markdown_links_absolute(extracted_markdown, base_url)
     fallback_text = BeautifulSoup(content_html_for_markdown, "html.parser").get_text(separator="\n").strip()
-    metadata = extract_html_metadata(content_html, base_url)
     if source_url:
         metadata["url"] = source_url
     return _finalize_content(title, extracted_markdown, fallback_text, intro_min_length, metadata)

--- a/packages/markdown-this/tests/test_extractor.py
+++ b/packages/markdown-this/tests/test_extractor.py
@@ -68,3 +68,22 @@ def test_extract_main_content_emits_html_metadata() -> None:
         "date": "2026-08-06",
         "image": "https://cdn.example.com/hero.jpg",
     }
+
+
+def test_extract_main_content_excludes_structural_ad_slots() -> None:
+    html = """
+    <html><head><title>Story</title></head><body><article>
+      <p>Story text with enough content to be selected by readability.</p>
+      <div class="c-ad advertising">
+        <div class="c-ad__adzone"></div>
+        <div class="c-ad__placeholder"><span>PUBLICIDAD</span></div>
+      </div>
+      <p>More story text after the ad.</p>
+    </article></body></html>
+    """
+
+    _title, markdown, _fallback, _intro = extract_main_content(html, min_content_length=0)
+
+    assert "Story text" in markdown
+    assert "More story text" in markdown
+    assert "PUBLICIDAD" not in markdown


### PR DESCRIPTION
Pass generic advertising keywords to readability-lxml so ad slots from rendered bookmarklet HTML are excluded without site-specific DOM filters. Add a regression test for nested ad slots.