### PR TITLE
Use server account for bookmarklets

### DIFF
--- a/packages/markdown-web/README.md
+++ b/packages/markdown-web/README.md
@@ -46,10 +46,12 @@ account; otherwise the server token is used.
 
 ## Bookmarklets
 
-Visit `/bookmarklet/` to generate two bookmarklets. They capture the current
-document HTML in the browser, so they also work with pages rendered by
-JavaScript. The generated links contain a temporary server-side key rather
-than the raw Telegraph token.
+Visit `/bookmarklet/` to get two bookmarklets. Drag either link to your
+browser's bookmarks bar, then click it while reading a page. They capture the
+current document HTML in the browser, so they also work with pages rendered by
+JavaScript. Publishing uses the server's `TELEGRAPH_API_TOKEN` (or its
+automatically created account); the raw token is never included in the
+bookmarklet.
 
 ## Development
 

--- a/packages/markdown-web/src/markdown_web/app.py
+++ b/packages/markdown-web/src/markdown_web/app.py
@@ -140,17 +140,10 @@ async def telegraph_from_post(request: Request) -> JSONResponse:
 
 @app.get("/bookmarklet/", response_class=HTMLResponse)
 def bookmarklet_form(request: Request) -> HTMLResponse:
-    return templates.TemplateResponse(request=request, name="bookmarklet.html", context={"bookmarklets": None})
-
-
-@app.post("/bookmarklet/", response_class=HTMLResponse)
-async def create_bookmarklet(request: Request) -> HTMLResponse:
-    body = await request.body()
-    values = {key: items[-1] for key, items in parse_qs(body.decode("utf-8")).items() if items}
     try:
-        token = telegraph_tokens.resolve(values.get("access_token") or None)
+        token = telegraph_tokens.resolve()
+        key = bookmarklet_tokens.create(token)
+        bookmarks = build_bookmarklets(str(request.base_url).rstrip("/"), key)
     except Exception as exc:
         raise _handle_source_error(exc) from exc
-    key = bookmarklet_tokens.create(token)
-    bookmarks = build_bookmarklets(str(request.base_url).rstrip("/"), key)
     return templates.TemplateResponse(request=request, name="bookmarklet.html", context={"bookmarklets": bookmarks})

--- a/packages/markdown-web/src/markdown_web/static/styles.css
+++ b/packages/markdown-web/src/markdown_web/static/styles.css
@@ -100,9 +100,11 @@ textarea {
 .footer a { margin: 0 4px; }
 .result .text-button { margin-top: 12px; }
 
-.lede { color: #777; font-size: 18px; }
+.lede { color: #666; font-size: 18px; }
 .bookmarklet-form { display: grid; gap: 14px; max-width: 460px; margin-top: 36px; }
 .bookmarklet-form .button { justify-self: start; margin-top: 12px; }
+.bookmarklet-instructions { max-width: 560px; margin: 28px 0 0; padding-left: 24px; }
+.bookmarklet-instructions li { margin: 10px 0; padding-left: 4px; }
 .bookmarklet-list { display: grid; gap: 16px; margin-top: 36px; }
 .bookmarklet { display: inline-block; width: fit-content; border-bottom: 1px solid #333; padding-bottom: 4px; text-decoration: none; }
 .note { margin-top: 36px; }

--- a/packages/markdown-web/src/markdown_web/templates/bookmarklet.html
+++ b/packages/markdown-web/src/markdown_web/templates/bookmarklet.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Bookmarklets | Page to Telegraph</title>
-    <link rel="stylesheet" href="/static/styles.css?v=3">
+    <link rel="stylesheet" href="/static/styles.css?v=4">
   </head>
   <body>
     <main class="page narrow">
@@ -12,21 +12,17 @@
         <a class="wordmark" href="/">Page to Telegraph</a>
       </header>
       <h1>Save the bookmarklets</h1>
-      {% if not bookmarklets %}
-      <p class="lede">Create two browser bookmarks that send the page you are reading here.</p>
-      <form method="post" class="bookmarklet-form">
-        <label for="access-token">Telegraph token <span>(optional)</span></label>
-        <input id="access-token" name="access_token" type="password" autocomplete="off" placeholder="Uses the server account when empty">
-        <button class="button button-primary" type="submit">Generate bookmarklets</button>
-      </form>
-      {% else %}
-      <p class="lede">Drag each link to your bookmarks bar.</p>
+      <p class="lede">Save these links as browser bookmarks to run them on the page you are reading.</p>
+      <ol class="bookmarklet-instructions">
+        <li>Drag either link below onto your browser's bookmarks bar.</li>
+        <li>Open an article you want to save.</li>
+        <li>Click the bookmark you saved. Markdown opens in a new tab; Telegraph publishes the page and opens it.</li>
+      </ol>
       <div class="bookmarklet-list">
         <a class="bookmarklet" href="{{ bookmarklets.markdown }}">Save as Markdown</a>
         <a class="bookmarklet" href="{{ bookmarklets.telegraph }}">Publish to Telegraph</a>
       </div>
-      <p class="note">The token stays on this server and is represented in the bookmarklets by a temporary key.</p>
-      {% endif %}
+      <p class="note">Publishing uses the server's Telegraph account. Your page content is sent directly from the browser.</p>
     </main>
     <footer class="footer">
       <a href="https://github.com/mgaitan/lobstersgram/tree/main/packages/markdown-web">GitHub</a>

--- a/packages/markdown-web/src/markdown_web/templates/index.html
+++ b/packages/markdown-web/src/markdown_web/templates/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Page to Telegraph</title>
-    <link rel="stylesheet" href="/static/styles.css?v=3">
+    <link rel="stylesheet" href="/static/styles.css?v=4">
   </head>
   <body>
     <main class="page">

--- a/packages/markdown-web/tests/test_app.py
+++ b/packages/markdown-web/tests/test_app.py
@@ -116,12 +116,14 @@ def test_get_telegraph_redirects(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_bookmarklet_form_does_not_expose_token(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("TELEGRAPH_API_TOKEN", "secret-token")
 
-    response = client.post("/bookmarklet/", data={"access_token": "secret-token"})
+    response = client.get("/bookmarklet/")
 
     assert response.status_code == HTTP_200_OK
     assert "Save as Markdown" in response.text
     assert "javascript:" in response.text
     assert "secret-token" not in response.text
+    assert "Generate bookmarklets" not in response.text
+    assert "Drag either link" in response.text
 
 
 def test_invalid_post_source_returns_client_error() -> None:


### PR DESCRIPTION
Remove public Telegraph token input from /bookmarklet/. Generate bookmarklets immediately with the server account and add step-by-step instructions for saving and using them.