### PR TITLE
Add AnyDoc document support to markdown-web

### DIFF
--- a/packages/markdown-web/README.md
+++ b/packages/markdown-web/README.md
@@ -27,6 +27,12 @@ by this running service. POST `/t` always publishes the supplied content.
 GET `/t/published/` lists the pages published by the configured Telegraph account.
 The original source is shown when Telegraph has it in the page's author URL.
 
+The home page also accepts document uploads. The web package uses
+[`firecrawl-anydoc`](https://github.com/firecrawl/anydoc) to convert PDF, Word,
+PowerPoint, Excel, OpenDocument, RTF, EPUB, and CSV files to Markdown. Uploads
+are limited to 50 MB. URLs ending in one of those document extensions are
+converted through the same path.
+
 The target URL should be URL-encoded when it contains characters that have a
 meaning to the web server. POST endpoints accept JSON with a URL, raw HTML, or
 Markdown:
@@ -45,6 +51,13 @@ Raw HTML can also be posted as `text/html`. Optional metadata is supplied with
 `X-Source-URL`, `X-Title`, `X-Author-Name`, `X-Published-Date`, and `X-Image-URL`.
 An `access_token` JSON field or `Authorization` header can select a Telegraph
 account; otherwise the server token is used.
+
+Documents can be posted as multipart form data using the `file` field:
+
+```bash
+curl -X POST http://127.0.0.1:8000/md \
+  -F 'file=@report.epub'
+```
 
 ## Bookmarklets
 

--- a/packages/markdown-web/pyproject.toml
+++ b/packages/markdown-web/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "markdown-web"
-version = "0.1.4"
+version = "0.1.5"
 description = "Minimal web service for extracting Markdown and publishing it to Telegraph"
 readme = "README.md"
 authors = [{ name = "Martín Gaitán", email = "gaitan@gmail.com" }]
@@ -9,6 +9,7 @@ requires-python = ">=3.12"
 keywords = ["markdown", "telegraph", "fastapi", "bookmarklet"]
 dependencies = [
     "fastapi[standard]>=0.116.1",
+    "firecrawl-anydoc>=0.1.6",
     "jinja2>=3.1.6",
     "markdown-this>=0.1.6",
     "md-to-telegraph>=0.1.5",

--- a/packages/markdown-web/src/markdown_web/app.py
+++ b/packages/markdown-web/src/markdown_web/app.py
@@ -13,6 +13,7 @@ from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse, Red
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from md_to_telegraph import TelegraphContentError
+from starlette.datastructures import UploadFile
 
 from markdown_web.bookmarklet import build_bookmarklets
 from markdown_web.schemas import SourceMetadata, SourceRequest
@@ -64,7 +65,20 @@ async def _request_data(request: Request) -> SourceRequest:
             image=values.pop("image", ""),
         )
         return SourceRequest(**values, metadata=metadata)
-    raise HTTPException(status_code=415, detail="Use application/json, text/html, or form-urlencoded")
+    if content_type == "multipart/form-data":
+        form = await request.form()
+        upload = form.get("file") or form.get("document")
+        if not isinstance(upload, UploadFile):
+            raise HTTPException(status_code=400, detail="Include a document in the file field")
+        metadata = SourceMetadata(
+            title=str(form.get("title", "")),
+            author=str(form.get("author", "")),
+            url=str(form.get("source_url", "")),
+            date=str(form.get("date", "")),
+            image=str(form.get("image", "")),
+        )
+        return SourceRequest(document=await upload.read(), filename=upload.filename or "", metadata=metadata)
+    raise HTTPException(status_code=415, detail="Use JSON, HTML, form-urlencoded, or multipart form data")
 
 
 def _source_request_from_path(url: str, request: Request) -> SourceRequest:

--- a/packages/markdown-web/src/markdown_web/schemas.py
+++ b/packages/markdown-web/src/markdown_web/schemas.py
@@ -25,5 +25,7 @@ class SourceRequest(BaseModel):
     url: str | None = None
     html: str | None = None
     markdown: str | None = None
+    document: bytes | None = None
+    filename: str = ""
     metadata: SourceMetadata = Field(default_factory=SourceMetadata)
     access_token: str | None = None

--- a/packages/markdown-web/src/markdown_web/service.py
+++ b/packages/markdown-web/src/markdown_web/service.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import os
 import threading
 from dataclasses import dataclass
+from pathlib import Path
 from urllib.parse import urlparse
 
+import anydoc
 import requests
 from markdown_this import add_front_matter, extract_main_content, markdown_to_text, split_front_matter
 from md_to_telegraph import create_account, create_page
@@ -18,6 +20,27 @@ DEFAULT_AUTHOR_NAME = "page-to-telegraph"
 TELEGRAPH_API_URL = "https://api.telegra.ph"
 TELEGRAPH_PAGE_LIST_LIMIT = 200
 TELEGRAPH_REQUEST_TIMEOUT = 20
+MAX_DOCUMENT_BYTES = 50 * 1024 * 1024
+DOCUMENT_EXTENSIONS = frozenset(
+    {
+        "doc",
+        "docx",
+        "docm",
+        "ppt",
+        "pptx",
+        "pptm",
+        "xls",
+        "xlsx",
+        "xlsm",
+        "odt",
+        "ods",
+        "odp",
+        "rtf",
+        "epub",
+        "csv",
+        "pdf",
+    }
+)
 
 
 class SourceError(ValueError):
@@ -36,6 +59,35 @@ class InvalidURLSourceError(SourceError):
 
     def __init__(self) -> None:
         super().__init__("URL sources must use http or https")
+
+
+class DocumentSourceError(SourceError):
+    """Raised when a document cannot be converted to Markdown."""
+
+
+class EmptyDocumentError(DocumentSourceError):
+    def __init__(self) -> None:
+        super().__init__("Uploaded document is empty")
+
+
+class DocumentTooLargeError(DocumentSourceError):
+    def __init__(self) -> None:
+        super().__init__("Documents must be 50 MB or smaller")
+
+
+class DocumentConversionError(DocumentSourceError):
+    def __init__(self, detail: Exception) -> None:
+        super().__init__(f"Could not convert document: {detail}")
+
+
+class EmptyDocumentContentError(DocumentSourceError):
+    def __init__(self) -> None:
+        super().__init__("Document did not contain readable content")
+
+
+class DocumentDownloadError(DocumentSourceError):
+    def __init__(self) -> None:
+        super().__init__("Could not download document")
 
 
 class TelegraphAPIError(RuntimeError):
@@ -139,6 +191,37 @@ def _require_source(request: SourceRequest) -> str:
     raise MissingSourceError
 
 
+def _is_document_url(url: str) -> bool:
+    suffix = Path(urlparse(url).path).suffix.lower().lstrip(".")
+    return suffix in DOCUMENT_EXTENSIONS
+
+
+def _convert_document(data: bytes, filename: str) -> str:
+    if not data:
+        raise EmptyDocumentError
+    if len(data) > MAX_DOCUMENT_BYTES:
+        raise DocumentTooLargeError
+    extension = Path(filename).suffix.lower().lstrip(".")
+    document_format = anydoc.format_from_extension(extension) if extension else None
+    try:
+        markdown = anydoc.to_markdown_bytes(data, document_format)
+    except (anydoc.ConvertError, OSError, ValueError) as exc:
+        raise DocumentConversionError(exc) from exc
+    if not markdown.strip():
+        raise EmptyDocumentContentError
+    return markdown
+
+
+def _download_document(url: str) -> tuple[bytes, str]:
+    try:
+        response = requests.get(url, timeout=TELEGRAPH_REQUEST_TIMEOUT, headers={"User-Agent": "markdown-web"})
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        raise DocumentDownloadError from exc
+    filename = Path(urlparse(url).path).name or "document"
+    return response.content, filename
+
+
 def _merge_metadata(markdown: str, supplied: SourceMetadata) -> tuple[str, SourceMetadata]:
     existing, body = split_front_matter(markdown.strip())
     merged = {**existing, **supplied.values()}
@@ -147,18 +230,35 @@ def _merge_metadata(markdown: str, supplied: SourceMetadata) -> tuple[str, Sourc
 
 def prepare_content(request: SourceRequest) -> PreparedContent:
     """Extract and normalize a request into Markdown with YAML front matter."""
-    source = _require_source(request)
-    if request.url:
-        title, markdown, fallback_text, _intro = extract_main_content(request.url)
-    elif request.html is not None:
-        title, markdown, fallback_text, _intro = extract_main_content(request.html)
-    else:
-        front_matter, body = split_front_matter(source.strip())
-        title = front_matter.get("title", "")
-        markdown = source
+    if request.document is not None or (request.url and _is_document_url(request.url)):
+        document, filename = (
+            (request.document, request.filename)
+            if request.document is not None
+            else _download_document(request.url or "")
+        )
+        markdown = _convert_document(document or b"", filename)
+        metadata = request.metadata
+        if request.url and not metadata.url:
+            metadata = metadata.model_copy(update={"url": request.url})
+        if not metadata.title and filename:
+            metadata = metadata.model_copy(update={"title": Path(filename).stem})
+        front_matter, body = split_front_matter(markdown.strip())
+        title = metadata.title or front_matter.get("title", "") or Path(filename).stem or "Document"
         fallback_text = markdown_to_text(body)
+    else:
+        source = _require_source(request)
+        if request.url:
+            title, markdown, fallback_text, _intro = extract_main_content(request.url)
+        elif request.html is not None:
+            title, markdown, fallback_text, _intro = extract_main_content(request.html)
+        else:
+            front_matter, body = split_front_matter(source.strip())
+            title = front_matter.get("title", "")
+            markdown = source
+            fallback_text = markdown_to_text(body)
+        metadata = request.metadata
 
-    markdown, metadata = _merge_metadata(markdown, request.metadata)
+    markdown, metadata = _merge_metadata(markdown, metadata)
     title = metadata.title or title
     return PreparedContent(title=title, markdown=markdown, fallback_text=fallback_text, metadata=metadata)
 

--- a/packages/markdown-web/src/markdown_web/static/styles.css
+++ b/packages/markdown-web/src/markdown_web/static/styles.css
@@ -47,6 +47,9 @@ h1 {
 
 .source-form { display: block; }
 .source-entry { display: flex; gap: 18px; align-items: center; }
+.source-fields { flex: 1; display: grid; gap: 10px; }
+.file-choice { color: #666; font: 14px system-ui, sans-serif; cursor: pointer; }
+.file-choice input { width: auto; margin-left: 8px; }
 
 input, textarea {
   width: 100%;

--- a/packages/markdown-web/src/markdown_web/templates/index.html
+++ b/packages/markdown-web/src/markdown_web/templates/index.html
@@ -23,7 +23,12 @@
         <form id="process-form" class="source-form">
           <div id="source-entry" class="source-entry">
             <label class="sr-only" for="source-url">URL</label>
-            <input id="source-url" name="url" type="url" placeholder="Paste a URL" required autofocus>
+            <div class="source-fields">
+              <input id="source-url" name="url" type="url" placeholder="Paste a URL" autofocus>
+              <label class="file-choice" for="source-file">Choose a document
+                <input id="source-file" type="file" accept=".pdf,.doc,.docx,.epub,.ppt,.pptx,.xls,.xlsx,.odt,.ods,.odp,.rtf,.csv">
+              </label>
+            </div>
             <button id="submit-button" class="button button-primary" type="submit">Process</button>
           </div>
 
@@ -57,6 +62,7 @@
       const result = document.querySelector("#result");
       const output = document.querySelector("#markdown-output");
       const sourceInput = document.querySelector("#source-url");
+      const sourceFile = document.querySelector("#source-file");
       const sourceLabel = document.querySelector("#result-source");
       const status = document.querySelector("#status");
       let currentUrl = "";
@@ -89,12 +95,29 @@
         }
 
         currentUrl = sourceInput.value.trim();
+        const file = sourceFile.files[0];
+        if (!currentUrl && !file) {
+          setStatus("Paste a URL or choose a document", true);
+          sourceInput.focus();
+          return;
+        }
+        if (currentUrl && file) {
+          setStatus("Choose a URL or a document, not both", true);
+          return;
+        }
         setStatus("Processing…");
         try {
-          const response = await fetch("/md/" + encodeURIComponent(currentUrl));
+          let response;
+          if (file) {
+            const data = new FormData();
+            data.append("file", file);
+            response = await fetch("/md", {method: "POST", body: data});
+          } else {
+            response = await fetch("/md/" + encodeURIComponent(currentUrl));
+          }
           if (!response.ok) throw new Error(await response.text());
           output.value = await response.text();
-          sourceLabel.textContent = currentUrl;
+          sourceLabel.textContent = currentUrl || file.name;
           sourceEntry.hidden = true;
           result.hidden = false;
           mode = "publish";

--- a/packages/markdown-web/tests/test_app.py
+++ b/packages/markdown-web/tests/test_app.py
@@ -103,6 +103,23 @@ def test_post_markdown_accepts_raw_html_metadata(monkeypatch: pytest.MonkeyPatch
     assert seen["source"].metadata.url == "https://example.com"
 
 
+def test_post_markdown_accepts_document_upload(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, SourceRequest] = {}
+
+    def fake_prepare(source: SourceRequest) -> PreparedContent:
+        seen["source"] = source
+        return _prepared("# From document")
+
+    monkeypatch.setattr(app_module, "prepare_content", fake_prepare)
+
+    response = client.post("/md", files={"file": ("report.epub", b"document", "application/epub+zip")})
+
+    assert response.status_code == HTTP_200_OK
+    assert response.text == "# From document"
+    assert seen["source"].document == b"document"
+    assert seen["source"].filename == "report.epub"
+
+
 def test_post_telegraph_returns_json_and_accepts_bearer_token(monkeypatch: pytest.MonkeyPatch) -> None:
     seen: dict[str, SourceRequest] = {}
 

--- a/packages/markdown-web/tests/test_service.py
+++ b/packages/markdown-web/tests/test_service.py
@@ -38,6 +38,32 @@ def test_prepare_content_accepts_raw_html(monkeypatch: pytest.MonkeyPatch) -> No
     assert "url: https://example.com" in result.markdown
 
 
+def test_prepare_content_converts_uploaded_document(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(service.anydoc, "to_markdown_bytes", lambda data, document_format: "# Report\n\nBody")
+
+    result = service.prepare_content(SourceRequest(document=b"document", filename="report.epub"))
+
+    assert result.title == "report"
+    assert "title: report" in result.markdown
+    assert result.fallback_text == "Report\n\nBody"
+
+
+def test_prepare_content_downloads_document_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeResponse:
+        content = b"document"
+
+        def raise_for_status(self) -> None:
+            return None
+
+    monkeypatch.setattr(service.requests, "get", lambda *args, **kwargs: FakeResponse())
+    monkeypatch.setattr(service.anydoc, "to_markdown_bytes", lambda data, document_format: "# Report\n\nBody")
+
+    result = service.prepare_content(SourceRequest(url="https://example.com/report.epub"))
+
+    assert result.title == "report"
+    assert "url: https://example.com/report.epub" in result.markdown
+
+
 def test_prepare_content_keeps_markdown_front_matter() -> None:
     result = service.prepare_content(SourceRequest(markdown="---\ntitle: Existing\n---\n\n# Existing\n\nBody"))
 

--- a/uv.lock
+++ b/uv.lock
@@ -460,6 +460,21 @@ wheels = [
 ]
 
 [[package]]
+name = "firecrawl-anydoc"
+version = "0.1.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/a1/d9c9675eab93cf3780ca784bba572252ca717b4e9cb4ab6363f42e573a19/firecrawl_anydoc-0.1.6.tar.gz", hash = "sha256:c23806b2228a7bee2fb2d9accdfae1ba5062e46a292285781ac4bdbd87fff35b", size = 190241, upload-time = "2026-08-05T18:29:23.785Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/9e/7bea14ed71bec4678d4daad1610e7eef850301f28e2122bdffe6d997d9d8/firecrawl_anydoc-0.1.6-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:996aa4ff2848b0b4a259421561364ff888202744ec257ccdba09111488ebdfbf", size = 3326951, upload-time = "2026-08-05T18:29:12.61Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/af/342a3fcaab2d6cc80ecf636cbab9e3b29205467c21cf1ec6dbf9e2a77814/firecrawl_anydoc-0.1.6-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:f102e87c004bcf6de979a1697776774454f814d85893e47fedc58fdf838a2f9b", size = 3175663, upload-time = "2026-08-05T18:29:14.405Z" },
+    { url = "https://files.pythonhosted.org/packages/78/64/97f90fea4b77457fd5cb13d30aefed2f64ffc34e89764e789ed1520d5a2f/firecrawl_anydoc-0.1.6-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c9acbeb860656205677b7991cf17a39241968e0533f6fe1b9d24bb7688e63d6", size = 3220877, upload-time = "2026-08-05T18:29:15.926Z" },
+    { url = "https://files.pythonhosted.org/packages/db/0b/d2943ee6b5eab1a673fe96333070b67232e819cc39728294a7034176006f/firecrawl_anydoc-0.1.6-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d3e65bbe6709a3a02dc4faf6af8b387016ac4ac2a5b38a70a9f950a8efa492d0", size = 3431813, upload-time = "2026-08-05T18:29:17.408Z" },
+    { url = "https://files.pythonhosted.org/packages/26/ed/7c171ee10d7eb73ddcbc3d63cdd59695bb0ea6598491ea53c79e8a152350/firecrawl_anydoc-0.1.6-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:dd80d01f72d983d6190aa37f0ee772d0e0f313baad80cd266acd0e584a7274b2", size = 3389223, upload-time = "2026-08-05T18:29:19.022Z" },
+    { url = "https://files.pythonhosted.org/packages/05/fa/02d6f34cb30b745fc99a0eba62a3028e4590c2dd6be852ae2c24acc45e4c/firecrawl_anydoc-0.1.6-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:05d2c32513270d622ddade866fa67f9598eda8bc35df35cbca2d3a5f95202a09", size = 3672930, upload-time = "2026-08-05T18:29:20.449Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/53/eb2ccf69aad54fbf873b5bcf6766e240f7a94b9a22903674f262b010fadc/firecrawl_anydoc-0.1.6-cp310-abi3-win_amd64.whl", hash = "sha256:ad9134ad79fbef3d988bfc667ae083b8e18292bdeb8250e8623be251bb8229f3", size = 3491314, upload-time = "2026-08-05T18:29:22.154Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -782,10 +797,11 @@ requires-dist = [
 
 [[package]]
 name = "markdown-web"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "packages/markdown-web" }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },
+    { name = "firecrawl-anydoc" },
     { name = "jinja2" },
     { name = "markdown-this" },
     { name = "md-to-telegraph" },
@@ -796,6 +812,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.116.1" },
+    { name = "firecrawl-anydoc", specifier = ">=0.1.6" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "markdown-this", editable = "packages/markdown-this" },
     { name = "md-to-telegraph", editable = "packages/md-to-telegraph" },


### PR DESCRIPTION
## Summary

- add AnyDoc only to `markdown-web`
- accept document uploads and document URLs in `/md`
- preserve document filename and source URL metadata
- document supported formats and multipart usage

## Verification

- `241 passed`
- 100% workspace coverage
- Ruff and `git diff --check` pass

Trafilatura evaluation is tracked separately in #84.